### PR TITLE
fix: Adjust the debugger style to stretch across the tab

### DIFF
--- a/packages/ui/src/scrollable/Scrollable.css.ts
+++ b/packages/ui/src/scrollable/Scrollable.css.ts
@@ -68,4 +68,5 @@ export const content = style({
   overflow: "hidden",
   width: "max-content",
   height: "max-content",
+  minWidth: "100%",
 })


### PR DESCRIPTION
In the Debugger tab I've noticed that the content of the nodes tree is not stretched to occupy the entire available width of the tab.
It looked something like this:

![image](https://user-images.githubusercontent.com/2098439/184471748-450d6aff-4828-4c74-8e6b-2cc464b1e249.png)

This pull request should fix that - 

![image](https://user-images.githubusercontent.com/2098439/184471825-07160e93-3477-40f4-a4e1-740e7d6676e1.png)

Thanks :)