### PR TITLE
Component props

### DIFF
--- a/.changeset/cold-points-design.md
+++ b/.changeset/cold-points-design.md
@@ -1,0 +1,9 @@
+---
+"@solid-devtools/debugger": minor
+"@solid-devtools/ext-adapter": minor
+"solid-devtools-extension": minor
+"@solid-devtools/shared": patch
+"@solid-devtools/ui": patch
+---
+
+Track component props and display their values in the details of a inspected component.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "esbuild-plugin-solid": "^0.4.2",
     "object-observer": "^5.0.4",
     "prettier": "2.7.0",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "taze": "^0.8.0",
     "ts-jest": "^28.0.8",
     "tsup": "^6.2.3",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -53,7 +53,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "ts-node": "^10.9.1",
     "tsup": "^6.2.3",
     "typescript": "^4.8.2"

--- a/packages/debugger/src/index.ts
+++ b/packages/debugger/src/index.ts
@@ -3,8 +3,8 @@ import { attachDebugger } from "./roots"
 
 export { useDebugger } from "./plugin"
 export type {
-  FocusedState,
-  SetSelectedOwner,
+  InspectedState,
+  SetInspectedOwner,
   SignaledRoot,
   BatchComputationUpdatesHandler,
   PluginData,

--- a/packages/debugger/src/inspect.ts
+++ b/packages/debugger/src/inspect.ts
@@ -1,0 +1,123 @@
+import { Mapped, NodeID, Solid, NodeType } from "@solid-devtools/shared/graph"
+import { EncodedValue, encodeValue } from "@solid-devtools/shared/serialize"
+import { $PROXY } from "solid-js"
+import { observeValueUpdate, removeValueUpdateObserver } from "./update"
+import {
+  getNodeName,
+  getNodeType,
+  isSolidComponent,
+  isSolidComputation,
+  isSolidMemo,
+  markNodeID,
+  markNodesID,
+} from "./utils"
+
+export type SignalUpdateHandler = (nodeId: NodeID, value: unknown) => void
+
+export type WalkerSelectedResult = (
+  | { details: Mapped.OwnerDetails; owner: Solid.Owner }
+  | { details: null; owner: null }
+) & {
+  signalMap: Record<NodeID, Solid.Signal>
+  elementMap: Record<NodeID, HTMLElement>
+}
+
+// Globals set before collecting the owner details
+let $elementMap!: Record<NodeID, HTMLElement>
+let $signalMap!: Record<NodeID, Solid.Signal>
+
+const INSPECTOR = Symbol("inspector")
+
+function mapSignalNode(node: Solid.Signal, handler: SignalUpdateHandler): Mapped.Signal {
+  const id = markNodeID(node)
+  $signalMap[id] = node
+  observeValueUpdate(node, value => handler(id, value), INSPECTOR)
+  return {
+    type: getNodeType(node) as NodeType.Memo | NodeType.Signal,
+    name: getNodeName(node),
+    id,
+    observers: markNodesID(node.observers),
+    value: encodeValue(node.value, false, $elementMap),
+  }
+}
+
+export function clearOwnerObservers(owner: Solid.Owner): void {
+  if (owner.sourceMap)
+    Object.values(owner.sourceMap).forEach(node => removeValueUpdateObserver(node, INSPECTOR))
+  if (owner.owned) owner.owned.forEach(node => removeValueUpdateObserver(node, INSPECTOR))
+}
+
+export function collectOwnerDetails(
+  owner: Solid.Owner,
+  config: {
+    elementMap: Record<NodeID, HTMLElement>
+    signalUpdateHandler: SignalUpdateHandler
+  },
+): {
+  details: Mapped.OwnerDetails
+  signalMap: Record<NodeID, Solid.Signal>
+} {
+  const { elementMap, signalUpdateHandler } = config
+  const signalMap: Record<NodeID, Solid.Signal> = {}
+
+  // Set globals
+  $elementMap = elementMap
+  $signalMap = signalMap
+
+  // get owner path
+  const path: NodeID[] = []
+  let current: Solid.Owner | null = owner.owner
+  while (current) {
+    // * after we flatten the tree, we'll know the length of the path — no need to use unshift then
+    path.unshift(markNodeID(current))
+    current = current.owner
+  }
+
+  // map signals
+  const signals = owner.sourceMap
+    ? Object.values(owner.sourceMap).map(s => mapSignalNode(s, signalUpdateHandler))
+    : []
+  // map memos
+  owner.owned?.forEach(child => {
+    if (!isSolidMemo(child)) return
+    signals.push(mapSignalNode(child, signalUpdateHandler))
+  })
+
+  const details: Mapped.OwnerDetails = {
+    // id, name and type are already set in mapOwner
+    id: owner.sdtId!,
+    name: owner.sdtName!,
+    type: owner.sdtType!,
+    path,
+    signals,
+  }
+
+  if (isSolidComputation(owner)) {
+    details.value = encodeValue(owner.value, false, elementMap)
+    details.sources = markNodesID(owner.sources)
+    if (isSolidMemo(owner)) {
+      details.observers = markNodesID(owner.observers)
+    }
+    if (isSolidComponent(owner)) {
+      // map component props
+      const { props } = owner
+      const proxy = !!(props as any)[$PROXY]
+      const value = Object.entries(Object.getOwnPropertyDescriptors(props)).reduce(
+        (value, [key, descriptor]) => {
+          value[key] = {
+            signal: proxy || "get" in descriptor,
+            value: encodeValue(descriptor.get?.() ?? descriptor.value, false, elementMap),
+          }
+          return value
+        },
+        {} as Record<string, { signal: boolean; value: EncodedValue<false> }>,
+      )
+      details.props = { proxy, value }
+    }
+  }
+
+  return {
+    details,
+    signalMap,
+  }
+}

--- a/packages/debugger/src/inspect.ts
+++ b/packages/debugger/src/inspect.ts
@@ -10,6 +10,8 @@ import {
   isSolidMemo,
   markNodeID,
   markNodesID,
+  markOwnerName,
+  markOwnerType,
 } from "./utils"
 
 export type SignalUpdateHandler = (nodeId: NodeID, value: unknown) => void
@@ -85,10 +87,9 @@ export function collectOwnerDetails(
   })
 
   const details: Mapped.OwnerDetails = {
-    // id, name and type are already set in mapOwner
-    id: owner.sdtId!,
-    name: owner.sdtName!,
-    type: owner.sdtType!,
+    id: markNodeID(owner),
+    name: markOwnerName(owner),
+    type: markOwnerType(owner),
     path,
     signals,
   }

--- a/packages/debugger/src/plugin.ts
+++ b/packages/debugger/src/plugin.ts
@@ -12,7 +12,7 @@ import {
   ComputationUpdate,
   SignalUpdate,
 } from "@solid-devtools/shared/graph"
-import { EncodedValue, encodeValue } from "@solid-devtools/shared/serialize"
+import { EncodedValue, encodeValue, ElementMap } from "@solid-devtools/shared/serialize"
 import { createConsumers, untrackedCallback } from "@solid-devtools/shared/primitives"
 import { createBatchedUpdateEmitter, createInternalRoot } from "./utils"
 import { ComputationUpdateHandler } from "./walker"
@@ -46,7 +46,7 @@ export type SetInspectedOwner = (payload: { rootId: NodeID; nodeId: NodeID } | n
 export type InspectedState = Readonly<
   {
     signalMap: Record<NodeID, Solid.Signal>
-    elementMap: Record<NodeID, HTMLElement>
+    elementMap: ElementMap
   } & (
     | { id: null; rootId: null; owner: null; details: null }
     | { id: NodeID; rootId: NodeID; owner: Solid.Owner; details: Mapped.OwnerDetails }
@@ -59,7 +59,7 @@ const getNullInspected = (): InspectedState => ({
   owner: null,
   details: null,
   signalMap: {},
-  elementMap: {},
+  elementMap: new ElementMap(),
 })
 
 export type SignaledRoot = {
@@ -219,7 +219,7 @@ const exported = createInternalRoot(() => {
     if (!result || !result.inspectedOwner) return setInspected(getNullInspected())
 
     const owner = result.inspectedOwner
-    const elementMap: Record<NodeID, HTMLElement> = {}
+    const elementMap = new ElementMap()
     inspectedProps.clear()
     inspectedSignals.clear()
     const { details, signalMap } = collectOwnerDetails(owner, {

--- a/packages/debugger/src/server.ts
+++ b/packages/debugger/src/server.ts
@@ -19,7 +19,7 @@ export const useDebugger: typeof API.useDebugger = () => ({
   serialisedRoots: () => ({}),
   rootsUpdates: () => ({ removed: [], updated: [] }),
   components: () => ({}),
-  setFocusedOwner: noop,
+  setInspectedOwner: noop,
   inspected: {
     details: null,
     elementMap: {},

--- a/packages/debugger/src/server.ts
+++ b/packages/debugger/src/server.ts
@@ -28,7 +28,9 @@ export const useDebugger: typeof API.useDebugger = () => ({
     rootId: null,
     signalMap: {},
   },
-  setSelectedSignal: () => ({} as any),
+  handlePropsUpdate: () => noop,
+  setInspectedSignal: () => null,
+  setInspectedProp: noop,
 })
 
 // update

--- a/packages/debugger/src/server.ts
+++ b/packages/debugger/src/server.ts
@@ -3,6 +3,7 @@ import { Solid } from "@solid-devtools/shared/graph"
 import { UNNAMED } from "@solid-devtools/shared/variables"
 import * as API from "./index"
 import { createRoot } from "solid-js"
+import { ElementMap } from "@solid-devtools/shared/serialize"
 
 export { createUnownedRoot } from "./index"
 
@@ -22,7 +23,7 @@ export const useDebugger: typeof API.useDebugger = () => ({
   setInspectedOwner: noop,
   inspected: {
     details: null,
-    elementMap: {},
+    elementMap: new ElementMap(),
     id: null,
     owner: null,
     rootId: null,

--- a/packages/debugger/src/server.ts
+++ b/packages/debugger/src/server.ts
@@ -20,7 +20,7 @@ export const useDebugger: typeof API.useDebugger = () => ({
   rootsUpdates: () => ({ removed: [], updated: [] }),
   components: () => ({}),
   setFocusedOwner: noop,
-  focusedState: {
+  inspected: {
     details: null,
     elementMap: {},
     id: null,

--- a/packages/debugger/src/utils.ts
+++ b/packages/debugger/src/utils.ts
@@ -24,6 +24,9 @@ export const isSolidOwner = (o: Readonly<Solid.Owner> | Solid.Signal): o is Soli
 export const isSolidRoot = (o: Readonly<Solid.Owner>): o is Solid.Root =>
   o.sdtType === NodeType.Root || !isSolidComputation(o)
 
+export const isSolidComponent = (o: Readonly<Solid.Owner>): o is Solid.Component =>
+  isSolidComputation(o) && _isComponent(o)
+
 const _isComponent = (o: Readonly<AnyObject>): boolean => "componentName" in o
 
 const _isMemo = (o: Readonly<AnyObject>): boolean =>

--- a/packages/debugger/src/utils.ts
+++ b/packages/debugger/src/utils.ts
@@ -25,9 +25,7 @@ export const isSolidRoot = (o: Readonly<Solid.Owner>): o is Solid.Root =>
   o.sdtType === NodeType.Root || !isSolidComputation(o)
 
 export const isSolidComponent = (o: Readonly<Solid.Owner>): o is Solid.Component =>
-  isSolidComputation(o) && _isComponent(o)
-
-const _isComponent = (o: Readonly<AnyObject>): boolean => "componentName" in o
+  "componentName" in o
 
 const _isMemo = (o: Readonly<AnyObject>): boolean =>
   "value" in o && "comparator" in o && o.pure === true
@@ -61,7 +59,7 @@ export const getOwnerType = (o: Readonly<Solid.Owner>): NodeType => {
   if (!isSolidComputation(o)) return NodeType.Root
   // Precompiled components do not start with "_Hot$$"
   // we need a way to identify imported (3rd party) vs user components
-  if (_isComponent(o)) return NodeType.Component
+  if (isSolidComponent(o)) return NodeType.Component
   if (_isMemo(o)) {
     if (fnMatchesRefresh(o.fn)) return NodeType.Refresh
     return NodeType.Memo

--- a/packages/debugger/src/walker.ts
+++ b/packages/debugger/src/walker.ts
@@ -1,121 +1,21 @@
-import { $PROXY } from "solid-js"
 import { resolveElements } from "@solid-primitives/refs"
 import { NodeType, NodeID, Solid, Mapped } from "@solid-devtools/shared/graph"
-import { EncodedValue, encodeValue } from "@solid-devtools/shared/serialize"
-import {
-  getNodeName,
-  getNodeType,
-  isSolidComponent,
-  isSolidComputation,
-  isSolidMemo,
-  markNodeID,
-  markNodesID,
-  markOwnerName,
-  markOwnerType,
-} from "./utils"
-import { observeComputationUpdate, observeValueUpdate, removeValueUpdateObserver } from "./update"
+import { isSolidComputation, markNodeID, markOwnerName, markOwnerType } from "./utils"
+import { observeComputationUpdate } from "./update"
 
-export type SignalUpdateHandler = (nodeId: NodeID, value: unknown) => void
 export type ComputationUpdateHandler = (rootId: NodeID, nodeId: NodeID) => void
 
 // Globals set before each walker cycle
-let SelectedId: NodeID | null
+let InspectedId: NodeID | null
 let RootId: NodeID
-let OnSignalUpdate: SignalUpdateHandler
 let OnComputationUpdate: ComputationUpdateHandler
 let GatherComponents: boolean
 let Components: Mapped.Component[] = []
-let SelectedOwner: Solid.Owner | null
-let SelectedDetails: Mapped.OwnerDetails | null
-let SelectedSignalMap: Record<NodeID, Solid.Signal>
-let ElementMap: Record<NodeID, HTMLElement>
-
-const WALKER = Symbol("walker")
+let InspectedOwner: Solid.Owner | null
 
 function observeComputation(owner: Solid.Owner, id: NodeID) {
   if (isSolidComputation(owner))
     observeComputationUpdate(owner, OnComputationUpdate.bind(void 0, RootId, id))
-}
-
-function observeValue(node: Solid.Signal) {
-  const id = markNodeID(node)
-  // OnSignalUpdate will change
-  const handler = OnSignalUpdate
-  observeValueUpdate(node, value => handler(id, value), WALKER)
-}
-
-function mapSignalNode(node: Solid.Signal): Mapped.Signal {
-  const id = markNodeID(node)
-  SelectedSignalMap[id] = node
-  observeValue(node)
-  return {
-    type: getNodeType(node) as NodeType.Memo | NodeType.Signal,
-    name: getNodeName(node),
-    id,
-    observers: markNodesID(node.observers),
-    value: encodeValue(node.value, false, ElementMap),
-  }
-}
-
-export function clearOwnerObservers(owner: Solid.Owner): void {
-  if (owner.sourceMap)
-    Object.values(owner.sourceMap).forEach(node => removeValueUpdateObserver(node, WALKER))
-  if (owner.owned) owner.owned.forEach(node => removeValueUpdateObserver(node, WALKER))
-}
-
-function collectOwnerDetails(owner: Solid.Owner): void {
-  // get owner path
-  const path: NodeID[] = []
-  let current: Solid.Owner | null = owner.owner
-  while (current) {
-    // * after we flatten the tree, we'll know the length of the path — no need to use unshift then
-    path.unshift(markNodeID(current))
-    current = current.owner
-  }
-
-  // map signals
-  const signals = owner.sourceMap ? Object.values(owner.sourceMap).map(mapSignalNode) : []
-  // map memos
-  owner.owned?.forEach(child => {
-    if (!isSolidMemo(child)) return
-    signals.push(mapSignalNode(child))
-  })
-
-  const details: Mapped.OwnerDetails = {
-    // id, name and type are already set in mapOwner
-    id: owner.sdtId!,
-    name: owner.sdtName!,
-    type: owner.sdtType!,
-    path,
-    signals,
-  }
-
-  if (isSolidComputation(owner)) {
-    details.value = encodeValue(owner.value, false, ElementMap)
-    details.sources = markNodesID(owner.sources)
-    if (isSolidMemo(owner)) {
-      details.observers = markNodesID(owner.observers)
-    }
-    if (isSolidComponent(owner)) {
-      // map component props
-      const { props } = owner
-      const proxy = !!(props as any)[$PROXY]
-      const value = Object.entries(Object.getOwnPropertyDescriptors(props)).reduce(
-        (value, [key, descriptor]) => {
-          value[key] = {
-            signal: proxy || "get" in descriptor,
-            value: encodeValue(descriptor.get?.() ?? descriptor.value, false, ElementMap),
-          }
-          return value
-        },
-        {} as Record<string, { signal: boolean; value: EncodedValue<false> }>,
-      )
-      details.props = { proxy, value }
-    }
-  }
-
-  SelectedOwner = owner
-  SelectedDetails = details
 }
 
 function mapChildren({ owned, ownedRoots }: Readonly<Solid.Owner>): Mapped.Owner[] {
@@ -141,7 +41,7 @@ function mapOwner(owner: Solid.Owner, type?: NodeType): Mapped.Owner {
   const id = markNodeID(owner)
   const name = markOwnerName(owner)
 
-  if (id === SelectedId) collectOwnerDetails(owner)
+  if (id === InspectedId) InspectedOwner = owner
 
   observeComputation(owner, id)
 
@@ -159,58 +59,29 @@ function mapOwner(owner: Solid.Owner, type?: NodeType): Mapped.Owner {
   }
 }
 
-export type WalkerConfig = {
-  rootId: NodeID
-  onSignalUpdate: SignalUpdateHandler
-  onComputationUpdate: ComputationUpdateHandler
-  gatherComponents: boolean
-  selectedId: NodeID | null
-  elementMap?: Record<NodeID, HTMLElement>
-}
-
-export type WalkerSelectedResult = (
-  | { details: Mapped.OwnerDetails; owner: Solid.Owner }
-  | { details: null; owner: null }
-) & {
-  signalMap: Record<NodeID, Solid.Signal>
-  elementMap: Record<NodeID, HTMLElement>
+export type WalkerResult = {
+  tree: Mapped.Owner
+  components: Mapped.Component[]
+  inspectedOwner: Solid.Owner | null
 }
 
 export function walkSolidTree(
   owner: Solid.Owner,
-  config: WalkerConfig,
-): {
-  tree: Mapped.Owner
-  components: Mapped.Component[]
-  selected: WalkerSelectedResult
-} {
+  config: {
+    rootId: NodeID
+    onComputationUpdate: ComputationUpdateHandler
+    gatherComponents: boolean
+    inspectedId: NodeID | null
+  },
+): WalkerResult {
   // set the globals to be available for this walk cycle
-  SelectedId = config.selectedId
+  InspectedId = config.inspectedId
   RootId = config.rootId
-  OnSignalUpdate = config.onSignalUpdate
   OnComputationUpdate = config.onComputationUpdate
   GatherComponents = config.gatherComponents
-  SelectedOwner = null
-  SelectedDetails = null
-  SelectedSignalMap = {}
+  InspectedOwner = null
   Components = []
-  ElementMap = config.elementMap ?? {}
 
   const tree = mapOwner(owner)
-  const components = Components
-  const focusedOwner = SelectedOwner
-  const focusedOwnerDetails = SelectedDetails
-  const focusedOwnerSignalMap = SelectedSignalMap
-  const elementMap = ElementMap
-
-  return {
-    tree,
-    components,
-    selected: {
-      details: focusedOwnerDetails,
-      owner: focusedOwner,
-      signalMap: focusedOwnerSignalMap,
-      elementMap,
-    },
-  }
+  return { tree, components: Components, inspectedOwner: InspectedOwner }
 }

--- a/packages/debugger/src/walker.ts
+++ b/packages/debugger/src/walker.ts
@@ -100,8 +100,6 @@ function collectOwnerDetails(owner: Solid.Owner): void {
       // map component props
       const { props } = owner
       const proxy = !!(props as any)[$PROXY]
-      console.log(owner.sdtName, proxy)
-
       const value = Object.entries(Object.getOwnPropertyDescriptors(props)).reduce(
         (value, [key, descriptor]) => {
           value[key] = {

--- a/packages/debugger/test/inspect.test.tsx
+++ b/packages/debugger/test/inspect.test.tsx
@@ -1,0 +1,267 @@
+import { getOwner, NodeID, NodeType, Solid } from "@solid-devtools/shared/graph"
+import { ValueType } from "@solid-devtools/shared/serialize"
+import {
+  createComputed,
+  createMemo,
+  createRenderEffect,
+  createRoot,
+  createSignal,
+  JSX,
+} from "solid-js"
+import type * as API from "../src/inspect"
+
+const getModule = (): typeof API.collectOwnerDetails =>
+  require("../src/inspect").collectOwnerDetails
+
+describe("collectOwnerDetails", () => {
+  beforeEach(() => {
+    delete (window as any).Solid$$
+    jest.resetModules()
+  })
+
+  it("collects focused owner details", () =>
+    createRoot(dispose => {
+      const collectOwnerDetails = getModule()
+      const [s, setS] = createSignal(0, { name: "source" })
+
+      let owner!: Solid.Owner
+      const div = document.createElement("div")
+      const elementMap: Record<NodeID, HTMLElement> = {}
+
+      createComputed(
+        () => {
+          const focused = createMemo(
+            () => {
+              owner = getOwner()!
+              owner.sdtId = "ff"
+              s()
+              createSignal(div, { name: "element" })
+              const memo = createMemo(() => 0, undefined, { name: "memo" })
+              createRenderEffect(memo, undefined, { name: "render" })
+              return "value"
+            },
+            undefined,
+            { name: "focused" },
+          )
+          focused()
+        },
+        undefined,
+        { name: "WRAPPER" },
+      )
+
+      const { details, signalMap } = collectOwnerDetails(owner, {
+        elementMap,
+        inspectedProps: new Set(),
+        signalUpdateHandler: () => {},
+      })
+
+      expect(details).toEqual({
+        id: "ff",
+        name: "focused",
+        type: NodeType.Memo,
+        path: ["1", "0"],
+        value: { type: ValueType.String, value: "value" },
+        sources: ["5"],
+        observers: ["0"],
+        signals: [
+          {
+            type: NodeType.Signal,
+            id: "2",
+            name: "element",
+            observers: [],
+            value: { type: ValueType.Element, value: { name: "DIV", id: "0" } },
+          },
+          {
+            type: NodeType.Memo,
+            id: "3",
+            name: "memo",
+            observers: ["4"],
+            value: { type: ValueType.Number, value: 0 },
+          },
+        ],
+      })
+
+      expect(signalMap).toHaveProperty("2")
+      expect(signalMap).toHaveProperty("3")
+      expect(signalMap["2"].sdtId).toBe("2")
+      expect(signalMap["3"].sdtId).toBe("3")
+
+      expect(Object.keys(elementMap).length).toBe(1)
+      expect(elementMap).toHaveProperty("0")
+      expect(elementMap["0"]).toBe(div)
+
+      dispose()
+    }))
+
+  it("component props", () => {
+    const collectOwnerDetails = getModule()
+
+    createRoot(dispose => {
+      let elementMap: Record<NodeID, HTMLElement> = {}
+
+      let owner!: Solid.Owner
+      const TestComponent = (props: {
+        count: number
+        children: JSX.Element
+        nested: { foo: number; bar: string }
+      }) => {
+        owner = getOwner()!
+        return <div>{props.children}</div>
+      }
+      createRenderEffect(() => (
+        <TestComponent count={123} nested={{ foo: 1, bar: "2" }}>
+          <button>Click me</button>
+        </TestComponent>
+      ))
+
+      const { details } = collectOwnerDetails(owner, {
+        elementMap,
+        inspectedProps: new Set(),
+        signalUpdateHandler: () => {},
+      })
+
+      dispose()
+
+      expect(details).toEqual({
+        id: "2",
+        name: "TestComponent",
+        type: NodeType.Component,
+        signals: [],
+        sources: [],
+        path: ["1", "0"],
+        value: { type: ValueType.Element, value: { id: "0", name: "DIV" } },
+        props: {
+          proxy: false,
+          value: {
+            count: { signal: false, value: { type: ValueType.Number, value: 123 } },
+            children: {
+              signal: true,
+              value: { type: ValueType.Element, value: { id: "1", name: "BUTTON" } },
+            },
+            nested: { signal: false, value: { type: ValueType.Object, value: 2 } },
+          },
+        },
+      })
+
+      expect(Object.keys(elementMap).length).toBe(2)
+      expect(elementMap).toHaveProperty("0")
+      expect(elementMap).toHaveProperty("1")
+      expect(elementMap["0"]).toBeInstanceOf(HTMLDivElement)
+      expect(elementMap["1"]).toBeInstanceOf(HTMLButtonElement)
+    })
+  })
+
+  it("dynamic component props", () =>
+    createRoot(dispose => {
+      const collectOwnerDetails = getModule()
+      let elementMap: Record<NodeID, HTMLElement> = {}
+
+      let owner!: Solid.Owner
+      const Button = (props: JSX.ButtonHTMLAttributes<HTMLButtonElement>) => {
+        owner = getOwner()!
+        return <button {...props}>Click me</button>
+      }
+      createRenderEffect(() => {
+        const props = () => ({ onClick: () => {}, role: "button" } as const)
+        return <Button {...props()} />
+      })
+
+      const { details } = collectOwnerDetails(owner, {
+        elementMap,
+        inspectedProps: new Set(),
+        signalUpdateHandler: () => {},
+      })
+
+      expect(details).toEqual({
+        id: "2",
+        name: "Button",
+        type: NodeType.Component,
+        signals: [],
+        sources: [],
+        path: ["1", "0"],
+        value: { type: ValueType.Element, value: { id: "0", name: "BUTTON" } },
+        props: {
+          // ! this should be true, don't know what's the reason. it's working in the browser
+          proxy: false,
+          value: {
+            onClick: { signal: true, value: { type: ValueType.Function, value: "onClick" } },
+            role: { signal: true, value: { type: ValueType.String, value: "button" } },
+          },
+        },
+      })
+
+      expect(Object.keys(elementMap).length).toBe(1)
+      expect(elementMap).toHaveProperty("0")
+      expect(elementMap["0"]).toBeInstanceOf(HTMLButtonElement)
+
+      dispose()
+    }))
+
+  test("inspected component props", () => {
+    const collectOwnerDetails = getModule()
+
+    createRoot(dispose => {
+      let elementMap: Record<NodeID, HTMLElement> = {}
+
+      let owner!: Solid.Owner
+      const TestComponent = (props: {
+        count: number
+        children: JSX.Element
+        nested: { foo: number; bar: string }
+      }) => {
+        owner = getOwner()!
+        return <div>{props.children}</div>
+      }
+      createRenderEffect(() => (
+        <TestComponent count={123} nested={{ foo: 1, bar: "2" }}>
+          <button>Click me</button>
+        </TestComponent>
+      ))
+
+      const { details } = collectOwnerDetails(owner, {
+        elementMap,
+        inspectedProps: new Set(["nested"]),
+        signalUpdateHandler: () => {},
+      })
+
+      dispose()
+
+      expect(details).toEqual({
+        id: "2",
+        name: "TestComponent",
+        type: NodeType.Component,
+        signals: [],
+        sources: [],
+        path: ["1", "0"],
+        value: { type: ValueType.Element, value: { id: "0", name: "DIV" } },
+        props: {
+          proxy: false,
+          value: {
+            count: { signal: false, value: { type: ValueType.Number, value: 123 } },
+            children: {
+              signal: true,
+              value: { type: ValueType.Element, value: { id: "1", name: "BUTTON" } },
+            },
+            nested: {
+              signal: false,
+              value: {
+                type: ValueType.Object,
+                value: 2,
+                children: {
+                  foo: { type: ValueType.Number, value: 1 },
+                  bar: { type: ValueType.String, value: "2" },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(Object.keys(elementMap).length).toBe(2)
+      expect(elementMap).toHaveProperty("0")
+      expect(elementMap).toHaveProperty("1")
+      expect(elementMap["0"]).toBeInstanceOf(HTMLDivElement)
+      expect(elementMap["1"]).toBeInstanceOf(HTMLButtonElement)
+    })
+  })
+})

--- a/packages/debugger/test/inspect.test.tsx
+++ b/packages/debugger/test/inspect.test.tsx
@@ -1,4 +1,4 @@
-import { getOwner, NodeID, NodeType, Solid } from "@solid-devtools/shared/graph"
+import { getOwner, NodeType, Solid } from "@solid-devtools/shared/graph"
 import { ValueType } from "@solid-devtools/shared/serialize"
 import {
   createComputed,
@@ -13,6 +13,9 @@ import type * as API from "../src/inspect"
 const getModule = (): typeof API.collectOwnerDetails =>
   require("../src/inspect").collectOwnerDetails
 
+const getElementsMap = (): import("@solid-devtools/shared/serialize").ElementMap =>
+  new (require("@solid-devtools/shared/serialize").ElementMap)()
+
 describe("collectOwnerDetails", () => {
   beforeEach(() => {
     delete (window as any).Solid$$
@@ -26,7 +29,7 @@ describe("collectOwnerDetails", () => {
 
       let owner!: Solid.Owner
       const div = document.createElement("div")
-      const elementMap: Record<NodeID, HTMLElement> = {}
+      const elementMap = getElementsMap()
 
       createComputed(
         () => {
@@ -86,9 +89,7 @@ describe("collectOwnerDetails", () => {
       expect(signalMap["2"].sdtId).toBe("2")
       expect(signalMap["3"].sdtId).toBe("3")
 
-      expect(Object.keys(elementMap).length).toBe(1)
-      expect(elementMap).toHaveProperty("0")
-      expect(elementMap["0"]).toBe(div)
+      expect(elementMap.get("0")).toBe(div)
 
       dispose()
     }))
@@ -97,7 +98,7 @@ describe("collectOwnerDetails", () => {
     const collectOwnerDetails = getModule()
 
     createRoot(dispose => {
-      let elementMap: Record<NodeID, HTMLElement> = {}
+      let elementMap = getElementsMap()
 
       let owner!: Solid.Owner
       const TestComponent = (props: {
@@ -133,28 +134,21 @@ describe("collectOwnerDetails", () => {
         props: {
           proxy: false,
           record: {
-            count: { signal: false, value: { type: ValueType.Number, value: 123 } },
-            children: {
-              signal: true,
-              value: { type: ValueType.Element, value: { id: "1", name: "BUTTON" } },
-            },
-            nested: { signal: false, value: { type: ValueType.Object, value: 2 } },
+            count: { type: ValueType.Number, value: 123 },
+            children: { type: ValueType.Getter, value: "children" },
+            nested: { type: ValueType.Object, value: 2 },
           },
         },
       })
 
-      expect(Object.keys(elementMap).length).toBe(2)
-      expect(elementMap).toHaveProperty("0")
-      expect(elementMap).toHaveProperty("1")
-      expect(elementMap["0"]).toBeInstanceOf(HTMLDivElement)
-      expect(elementMap["1"]).toBeInstanceOf(HTMLButtonElement)
+      expect(elementMap.get("0")).toBeInstanceOf(HTMLDivElement)
     })
   })
 
   it("dynamic component props", () =>
     createRoot(dispose => {
       const collectOwnerDetails = getModule()
-      let elementMap: Record<NodeID, HTMLElement> = {}
+      let elementMap = getElementsMap()
 
       let owner!: Solid.Owner
       const Button = (props: JSX.ButtonHTMLAttributes<HTMLButtonElement>) => {
@@ -184,15 +178,13 @@ describe("collectOwnerDetails", () => {
           // ! this should be true, don't know what's the reason. it's working in the browser
           proxy: false,
           record: {
-            onClick: { signal: true, value: { type: ValueType.Function, value: "onClick" } },
-            role: { signal: true, value: { type: ValueType.String, value: "button" } },
+            onClick: { type: ValueType.Getter, value: "onClick" },
+            role: { type: ValueType.Getter, value: "role" },
           },
         },
       })
 
-      expect(Object.keys(elementMap).length).toBe(1)
-      expect(elementMap).toHaveProperty("0")
-      expect(elementMap["0"]).toBeInstanceOf(HTMLButtonElement)
+      expect(elementMap.get("0")).toBeInstanceOf(HTMLButtonElement)
 
       dispose()
     }))
@@ -201,7 +193,7 @@ describe("collectOwnerDetails", () => {
     const collectOwnerDetails = getModule()
 
     createRoot(dispose => {
-      let elementMap: Record<NodeID, HTMLElement> = {}
+      let elementMap = getElementsMap()
 
       let owner!: Solid.Owner
       const TestComponent = (props: {
@@ -237,31 +229,21 @@ describe("collectOwnerDetails", () => {
         props: {
           proxy: false,
           record: {
-            count: { signal: false, value: { type: ValueType.Number, value: 123 } },
-            children: {
-              signal: true,
-              value: { type: ValueType.Element, value: { id: "1", name: "BUTTON" } },
-            },
+            count: { type: ValueType.Number, value: 123 },
+            children: { type: ValueType.Getter, value: "children" },
             nested: {
-              signal: false,
-              value: {
-                type: ValueType.Object,
-                value: 2,
-                children: {
-                  foo: { type: ValueType.Number, value: 1 },
-                  bar: { type: ValueType.String, value: "2" },
-                },
+              type: ValueType.Object,
+              value: 2,
+              children: {
+                foo: { type: ValueType.Number, value: 1 },
+                bar: { type: ValueType.String, value: "2" },
               },
             },
           },
         },
       })
 
-      expect(Object.keys(elementMap).length).toBe(2)
-      expect(elementMap).toHaveProperty("0")
-      expect(elementMap).toHaveProperty("1")
-      expect(elementMap["0"]).toBeInstanceOf(HTMLDivElement)
-      expect(elementMap["1"]).toBeInstanceOf(HTMLButtonElement)
+      expect(elementMap.get("0")).toBeInstanceOf(HTMLDivElement)
     })
   })
 })

--- a/packages/debugger/test/inspect.test.tsx
+++ b/packages/debugger/test/inspect.test.tsx
@@ -132,7 +132,7 @@ describe("collectOwnerDetails", () => {
         value: { type: ValueType.Element, value: { id: "0", name: "DIV" } },
         props: {
           proxy: false,
-          value: {
+          record: {
             count: { signal: false, value: { type: ValueType.Number, value: 123 } },
             children: {
               signal: true,
@@ -183,7 +183,7 @@ describe("collectOwnerDetails", () => {
         props: {
           // ! this should be true, don't know what's the reason. it's working in the browser
           proxy: false,
-          value: {
+          record: {
             onClick: { signal: true, value: { type: ValueType.Function, value: "onClick" } },
             role: { signal: true, value: { type: ValueType.String, value: "button" } },
           },
@@ -236,7 +236,7 @@ describe("collectOwnerDetails", () => {
         value: { type: ValueType.Element, value: { id: "0", name: "DIV" } },
         props: {
           proxy: false,
-          value: {
+          record: {
             count: { signal: false, value: { type: ValueType.Number, value: 123 } },
             children: {
               signal: true,

--- a/packages/debugger/test/walker.test.tsx
+++ b/packages/debugger/test/walker.test.tsx
@@ -51,11 +51,10 @@ describe("walkSolidTree", () => {
       return [dispose, getOwner()!]
     })
 
-    const { tree, components, selected } = walkSolidTree(owner, {
+    const { tree, components, inspectedOwner } = walkSolidTree(owner, {
       onComputationUpdate: () => {},
-      onSignalUpdate: () => {},
       rootId: "ff",
-      selectedId: null,
+      inspectedId: null,
       gatherComponents: false,
     })
 
@@ -93,12 +92,7 @@ describe("walkSolidTree", () => {
     })
     expect(tree).toEqual(JSON.parse(JSON.stringify(tree)))
     expect(components).toEqual([])
-    expect(selected).toEqual({
-      details: null,
-      owner: null,
-      signalMap: {},
-      elementMap: {},
-    })
+    expect(inspectedOwner).toBe(null)
   })
 
   it("listen to computation updates", () =>
@@ -112,9 +106,8 @@ describe("walkSolidTree", () => {
 
       walkSolidTree(getOwner()!, {
         onComputationUpdate: (rootId, id) => capturedComputationUpdates.push([rootId, id]),
-        onSignalUpdate: () => {},
         rootId: "ff",
-        selectedId: null,
+        inspectedId: null,
         gatherComponents: false,
       })
 
@@ -152,9 +145,8 @@ describe("walkSolidTree", () => {
 
       const { components } = walkSolidTree(getOwner()!, {
         onComputationUpdate: () => {},
-        onSignalUpdate: () => {},
         rootId: "ff",
-        selectedId: null,
+        inspectedId: null,
         gatherComponents: true,
       })
 
@@ -175,14 +167,13 @@ describe("walkSolidTree", () => {
       dispose()
     }))
 
-  it("collects focused owner details", () =>
+  it("returns inspected owner", () =>
     createRoot(dispose => {
       const walkSolidTree = getModule()
       const [s, setS] = createSignal(0, { name: "source" })
 
       let owner!: Solid.Owner
       const div = document.createElement("div")
-      const elementMap: Record<NodeID, HTMLElement> = {}
 
       createComputed(
         () => {
@@ -205,16 +196,14 @@ describe("walkSolidTree", () => {
         { name: "WRAPPER" },
       )
 
-      const { tree, selected } = walkSolidTree(getOwner()!, {
+      const { tree, inspectedOwner } = walkSolidTree(getOwner()!, {
         rootId: "0",
-        selectedId: "ff",
+        inspectedId: "ff",
         onComputationUpdate: () => {},
-        onSignalUpdate: () => {},
         gatherComponents: false,
-        elementMap,
       })
 
-      expect(owner).toBe(selected.owner)
+      expect(owner).toBe(inspectedOwner)
 
       expect(tree).toEqual({
         id: "0",
@@ -235,14 +224,14 @@ describe("walkSolidTree", () => {
                 type: NodeType.Memo,
                 children: [
                   {
-                    id: "3",
+                    id: "2",
                     name: "memo",
                     sources: 0,
                     type: NodeType.Memo,
                     children: [],
                   },
                   {
-                    id: "4",
+                    id: "3",
                     name: "render",
                     sources: 1,
                     type: NodeType.Render,
@@ -254,147 +243,6 @@ describe("walkSolidTree", () => {
           },
         ],
       })
-
-      expect(selected.details).toEqual({
-        id: "ff",
-        name: "focused",
-        type: NodeType.Memo,
-        path: ["0", "1"],
-        signals: [
-          {
-            type: NodeType.Signal,
-            id: "2",
-            name: "element",
-            observers: [],
-            value: { type: ValueType.Element, value: { name: "DIV", id: "0" } },
-          },
-          {
-            type: NodeType.Memo,
-            id: "3",
-            name: "memo",
-            observers: ["4"],
-            value: { type: ValueType.Number, value: 0 },
-          },
-        ],
-        value: { type: ValueType.String, value: "value" },
-        sources: ["5"],
-        observers: ["1"],
-      })
-
-      expect(selected.signalMap).toHaveProperty("2")
-      expect(selected.signalMap).toHaveProperty("3")
-      expect(selected.signalMap["2"].sdtId).toBe("2")
-      expect(selected.signalMap["3"].sdtId).toBe("3")
-
-      expect(selected.elementMap).toBe(elementMap)
-      expect(Object.keys(elementMap).length).toBe(1)
-      expect(elementMap).toHaveProperty("0")
-      expect(elementMap["0"]).toBe(div)
-
-      dispose()
-    }))
-
-  it("selected component props", () =>
-    createRoot(dispose => {
-      let elementMap: Record<NodeID, HTMLElement> = {}
-      const walkSolidTree = getModule()
-
-      const TestComponent = (props: { count: number; children: JSX.Element }) => {
-        return <div>{props.children}</div>
-      }
-      createRenderEffect(() => (
-        <TestComponent count={123}>
-          <button>Click me</button>
-        </TestComponent>
-      ))
-
-      const { selected } = walkSolidTree(getOwner()!, {
-        rootId: "0",
-        selectedId: "2",
-        onComputationUpdate: () => {},
-        onSignalUpdate: () => {},
-        gatherComponents: false,
-        elementMap,
-      })
-
-      expect(selected.details).toEqual({
-        id: "2",
-        name: "TestComponent",
-        type: NodeType.Component,
-        signals: [],
-        sources: [],
-        path: ["0", "1"],
-        value: { type: ValueType.Element, value: { id: "0", name: "DIV" } },
-        props: {
-          proxy: false,
-          value: {
-            count: { signal: false, value: { type: ValueType.Number, value: 123 } },
-            children: {
-              signal: true,
-              value: { type: ValueType.Element, value: { id: "1", name: "BUTTON" } },
-            },
-          },
-        },
-      })
-
-      expect(selected.elementMap).toBe(elementMap)
-      expect(Object.keys(elementMap).length).toBe(2)
-      expect(elementMap).toHaveProperty("0")
-      expect(elementMap).toHaveProperty("1")
-      expect(elementMap["0"]).toBeInstanceOf(HTMLDivElement)
-      expect(elementMap["1"]).toBeInstanceOf(HTMLButtonElement)
-
-      dispose()
-    }))
-
-  it("selected dynamic component props", () =>
-    createRoot(dispose => {
-      let elementMap: Record<NodeID, HTMLElement> = {}
-      const walkSolidTree = getModule()
-
-      const Button = (props: JSX.ButtonHTMLAttributes<HTMLButtonElement>) => {
-        console.log(!!(props as any)[$PROXY])
-
-        return <button {...props}>Click me</button>
-      }
-      createRenderEffect(() => {
-        const props = () => ({ onClick: () => {}, role: "button" } as const)
-        return <Button {...props()} />
-      })
-
-      const { selected } = walkSolidTree(getOwner()!, {
-        rootId: "0",
-        selectedId: "2",
-        onComputationUpdate: () => {},
-        onSignalUpdate: () => {},
-        gatherComponents: false,
-        elementMap,
-      })
-
-      expect(selected.details).toEqual({
-        id: "2",
-        name: "Button",
-        type: NodeType.Component,
-        signals: [],
-        sources: [],
-        path: ["0", "1"],
-        value: { type: ValueType.Element, value: { id: "0", name: "BUTTON" } },
-        props: {
-          // ! this should be true, don't know what's the reason. it's working in the browser
-          proxy: false,
-          value: {
-            onClick: { signal: true, value: { type: ValueType.Function, value: "onClick" } },
-            role: { signal: true, value: { type: ValueType.String, value: "button" } },
-          },
-        },
-      })
-
-      expect(selected.elementMap).toBe(elementMap)
-      expect(Object.keys(elementMap).length).toBe(1)
-      expect(elementMap).toHaveProperty("0")
-      expect(elementMap["0"]).toBeInstanceOf(HTMLButtonElement)
-
-      elementMap = {}
 
       dispose()
     }))

--- a/packages/ext-adapter/package.json
+++ b/packages/ext-adapter/package.json
@@ -35,7 +35,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "tsup": "^6.2.3",
     "typescript": "^4.8.2"
   },

--- a/packages/ext-adapter/src/index.ts
+++ b/packages/ext-adapter/src/index.ts
@@ -28,6 +28,7 @@ createInternalRoot(() => {
     roots,
     handleComputationUpdates,
     handleSignalUpdates,
+    handlePropsUpdate,
     setInspectedOwner,
     inspected,
     setInspectedSignal,
@@ -63,26 +64,23 @@ createInternalRoot(() => {
         }
         // toggled prop
         else {
-          const { key, selected } = payload
-          setInspectedProp(key, selected)
+          const { id, selected } = payload
+          setInspectedProp(id, selected)
         }
       }),
     )
 
     // diff the roots, and send only the changed roots (edited, deleted, added)
-    createEffect(() => {
-      postWindowMessage("GraphUpdate", rootsUpdates())
-    })
+    createEffect(() => postWindowMessage("GraphUpdate", rootsUpdates()))
 
     // send the computation updates
-    handleComputationUpdates(updates => {
-      postWindowMessage("ComputationUpdates", updates)
-    })
+    handleComputationUpdates(updates => postWindowMessage("ComputationUpdates", updates))
 
     // send the signal updates
-    handleSignalUpdates(updates => {
-      postWindowMessage("SignalUpdates", updates)
-    })
+    handleSignalUpdates(updates => postWindowMessage("SignalUpdates", updates))
+
+    // send the props updates
+    handlePropsUpdate(updates => postWindowMessage("PropsUpdate", updates))
 
     // send the focused owner details
     createEffect(() => {

--- a/packages/ext-adapter/src/index.ts
+++ b/packages/ext-adapter/src/index.ts
@@ -143,7 +143,7 @@ createInternalRoot(() => {
         }
         // highlight element
         else {
-          const element = inspected.elementMap[payload]
+          const element = inspected.elementMap.get(payload)
           if (!element) return warn("No element found", payload)
           target = element
         }

--- a/packages/ext-adapter/src/index.ts
+++ b/packages/ext-adapter/src/index.ts
@@ -32,7 +32,7 @@ createInternalRoot(() => {
     handleComputationUpdates,
     handleSignalUpdates,
     setFocusedOwner,
-    focusedState,
+    inspected,
     setSelectedSignal,
   } = useDebugger({ enabled, observeComputations: enabled })
 
@@ -70,7 +70,7 @@ createInternalRoot(() => {
 
     // send the focused owner details
     createEffect(() => {
-      const details = focusedState.details
+      const details = inspected.details
       if (details) postWindowMessage("OwnerDetailsUpdate", details)
     })
 
@@ -129,7 +129,7 @@ createInternalRoot(() => {
         }
         // highlight element
         else {
-          const element = focusedState.elementMap[payload]
+          const element = inspected.elementMap[payload]
           if (!element) return warn("No element found", payload)
           target = element
         }

--- a/packages/ext-adapter/src/index.ts
+++ b/packages/ext-adapter/src/index.ts
@@ -30,7 +30,8 @@ createInternalRoot(() => {
     handleSignalUpdates,
     setInspectedOwner,
     inspected,
-    setSelectedSignal,
+    setInspectedSignal,
+    setInspectedProp,
   } = useDebugger({ enabled })
 
   // update the graph only if the devtools panel is in view
@@ -53,9 +54,18 @@ createInternalRoot(() => {
     onCleanup(onWindowMessage("SetSelectedOwner", setInspectedOwner))
 
     onCleanup(
-      onWindowMessage("SetSelectedSignal", ({ id, selected }) => {
-        const value = setSelectedSignal({ id, selected })
-        if (value) postWindowMessage("SignalValue", { id, value })
+      onWindowMessage("ToggleInspectedValue", payload => {
+        // toggled signal
+        if (payload.type === "signal") {
+          const { id, selected } = payload
+          const value = setInspectedSignal(id, selected)
+          if (value) postWindowMessage("SignalValue", { id, value })
+        }
+        // toggled prop
+        else {
+          const { key, selected } = payload
+          setInspectedProp(key, selected)
+        }
       }),
     )
 

--- a/packages/extension/background/background.ts
+++ b/packages/extension/background/background.ts
@@ -26,7 +26,7 @@ chrome.runtime.onConnect.addListener(port => {
   if (port.name === DEVTOOLS_CONNECTION_NAME) {
     const disconnectListener = () => {
       panelVisibility = false
-      postPortMessage("PanelVisibility", false)
+      postPortMessage("PanelClosed", true)
       port.onDisconnect.removeListener(disconnectListener)
     }
     port.onDisconnect.addListener(disconnectListener)

--- a/packages/extension/background/background.ts
+++ b/packages/extension/background/background.ts
@@ -71,10 +71,11 @@ chrome.runtime.onConnect.addListener(port => {
   addCleanup(onPortMessage("ComputationUpdates", e => postRuntimeMessage("ComputationUpdates", e)))
 
   addCleanup(onPortMessage("SignalUpdates", e => postRuntimeMessage("SignalUpdates", e)))
+  addCleanup(onPortMessage("SignalValue", e => postRuntimeMessage("SignalValue", e)))
 
   addCleanup(onPortMessage("OwnerDetailsUpdate", e => postRuntimeMessage("OwnerDetailsUpdate", e)))
 
-  addCleanup(onPortMessage("SignalValue", e => postRuntimeMessage("SignalValue", e)))
+  addCleanup(onPortMessage("PropsUpdate", e => postRuntimeMessage("PropsUpdate", e)))
 
   addCleanup(onPortMessage("SetHoveredOwner", e => postRuntimeMessage("SetHoveredOwner", e)))
 

--- a/packages/extension/background/background.ts
+++ b/packages/extension/background/background.ts
@@ -27,6 +27,7 @@ chrome.runtime.onConnect.addListener(port => {
     const disconnectListener = () => {
       panelVisibility = false
       postPortMessage("PanelClosed", true)
+      log("Devtools Port disconnected")
       port.onDisconnect.removeListener(disconnectListener)
     }
     port.onDisconnect.addListener(disconnectListener)
@@ -37,51 +38,43 @@ chrome.runtime.onConnect.addListener(port => {
   if (port.name !== DEVTOOLS_CONTENT_PORT) return log("Ignored connection:", port.name)
 
   if (currentPort) {
-    log(`Switching BG Ports: ${currentPort.sender?.documentId} -> ${port.sender?.documentId}`)
+    log(`Switching Content Ports: ${currentPort.sender?.documentId} -> ${port.sender?.documentId}`)
   }
 
   currentPort = port
   lastDocumentId = port.sender?.documentId
 
-  const { push: addCleanup, execute: clearListeners } = createCallbackStack()
+  const { push: addCleanup, execute: clearRuntimeListeners } = createCallbackStack()
 
   port.onDisconnect.addListener(() => {
-    clearListeners()
-    log("Port disconnected.")
+    clearRuntimeListeners()
+    log("Content Port disconnected.")
   })
 
   const messanger = createPortMessanger(port)
   postPortMessage = messanger.postPortMessage
   onPortMessage = messanger.onPortMessage
 
-  addCleanup(
-    onPortMessage("SolidOnPage", () => {
-      solidOnPage = true
-      postRuntimeMessage("SolidOnPage")
-      // respond with page visibility to the debugger, to let him know
-      // if the panel is already created and visible (after page refresh)
-      postPortMessage("PanelVisibility", panelVisibility)
-    }),
-  )
+  onPortMessage("SolidOnPage", () => {
+    solidOnPage = true
+    postRuntimeMessage("SolidOnPage")
+    // respond with page visibility to the debugger, to let him know
+    // if the panel is already created and visible (after page refresh)
+    postPortMessage("PanelVisibility", panelVisibility)
+  }),
+    onPortMessage("ResetPanel", () => postRuntimeMessage("ResetPanel"))
 
-  addCleanup(onPortMessage("ResetPanel", () => postRuntimeMessage("ResetPanel")))
+  onPortMessage("GraphUpdate", e => postRuntimeMessage("GraphUpdate", e))
 
-  addCleanup(onPortMessage("GraphUpdate", graph => postRuntimeMessage("GraphUpdate", graph)))
+  onPortMessage("ComputationUpdates", e => postRuntimeMessage("ComputationUpdates", e))
+  onPortMessage("SignalUpdates", e => postRuntimeMessage("SignalUpdates", e))
+  onPortMessage("SignalValue", e => postRuntimeMessage("SignalValue", e))
+  onPortMessage("OwnerDetailsUpdate", e => postRuntimeMessage("OwnerDetailsUpdate", e))
+  onPortMessage("PropsUpdate", e => postRuntimeMessage("PropsUpdate", e))
+  onPortMessage("SetHoveredOwner", e => postRuntimeMessage("SetHoveredOwner", e))
+  onPortMessage("SendSelectedOwner", e => postRuntimeMessage("SendSelectedOwner", e))
 
-  addCleanup(onPortMessage("ComputationUpdates", e => postRuntimeMessage("ComputationUpdates", e)))
-
-  addCleanup(onPortMessage("SignalUpdates", e => postRuntimeMessage("SignalUpdates", e)))
-  addCleanup(onPortMessage("SignalValue", e => postRuntimeMessage("SignalValue", e)))
-
-  addCleanup(onPortMessage("OwnerDetailsUpdate", e => postRuntimeMessage("OwnerDetailsUpdate", e)))
-
-  addCleanup(onPortMessage("PropsUpdate", e => postRuntimeMessage("PropsUpdate", e)))
-
-  addCleanup(onPortMessage("SetHoveredOwner", e => postRuntimeMessage("SetHoveredOwner", e)))
-
-  addCleanup(onPortMessage("SendSelectedOwner", e => postRuntimeMessage("SendSelectedOwner", e)))
-
-  addCleanup(onPortMessage("AdpLocatorMode", e => postRuntimeMessage("AdpLocatorMode", e)))
+  onPortMessage("AdpLocatorMode", e => postRuntimeMessage("AdpLocatorMode", e))
   addCleanup(onRuntimeMessage("ExtLocatorMode", e => postPortMessage("ExtLocatorMode", e)))
 
   addCleanup(
@@ -94,6 +87,7 @@ chrome.runtime.onConnect.addListener(port => {
   // make sure the devtools script will be triggered to create devtools panel
   addCleanup(
     onRuntimeMessage("DevtoolsScriptConnected", tabId => {
+      postPortMessage("DevtoolsScriptConnected", tabId)
       if (solidOnPage) postRuntimeMessage("SolidOnPage")
     }),
   )

--- a/packages/extension/background/background.ts
+++ b/packages/extension/background/background.ts
@@ -98,7 +98,10 @@ chrome.runtime.onConnect.addListener(port => {
   )
 
   addCleanup(onRuntimeMessage("SetSelectedOwner", e => postPortMessage("SetSelectedOwner", e)))
-  addCleanup(onRuntimeMessage("SetSelectedSignal", e => postPortMessage("SetSelectedSignal", e)))
+
+  addCleanup(
+    onRuntimeMessage("ToggleInspectedValue", e => postPortMessage("ToggleInspectedValue", e)),
+  )
 
   addCleanup(onRuntimeMessage("HighlightElement", e => postPortMessage("HighlightElement", e)))
 

--- a/packages/extension/content/content.ts
+++ b/packages/extension/content/content.ts
@@ -64,7 +64,7 @@ onWindowMessage("SendSelectedOwner", e => postPortMessage("SendSelectedOwner", e
 onPortMessage("PanelVisibility", e => postWindowMessage("PanelVisibility", e))
 onPortMessage("PanelClosed", e => postWindowMessage("PanelClosed", e))
 
-once(onPortMessage, "ForceUpdate", () => postWindowMessage("ForceUpdate"))
+onPortMessage("ForceUpdate", () => postWindowMessage("ForceUpdate"))
 
 onPortMessage("SetSelectedOwner", e => postWindowMessage("SetSelectedOwner", e))
 

--- a/packages/extension/content/content.ts
+++ b/packages/extension/content/content.ts
@@ -52,10 +52,11 @@ onWindowMessage("GraphUpdate", graph => postPortMessage("GraphUpdate", graph))
 onWindowMessage("ComputationUpdates", e => postPortMessage("ComputationUpdates", e))
 
 onWindowMessage("SignalUpdates", e => postPortMessage("SignalUpdates", e))
+onWindowMessage("SignalValue", e => postPortMessage("SignalValue", e))
 
 onWindowMessage("OwnerDetailsUpdate", e => postPortMessage("OwnerDetailsUpdate", e))
 
-onWindowMessage("SignalValue", e => postPortMessage("SignalValue", e))
+onWindowMessage("PropsUpdate", e => postPortMessage("PropsUpdate", e))
 
 onWindowMessage("SetHoveredOwner", e => postPortMessage("SetHoveredOwner", e))
 

--- a/packages/extension/content/content.ts
+++ b/packages/extension/content/content.ts
@@ -61,7 +61,8 @@ onWindowMessage("SetHoveredOwner", e => postPortMessage("SetHoveredOwner", e))
 
 onWindowMessage("SendSelectedOwner", e => postPortMessage("SendSelectedOwner", e))
 
-onPortMessage("PanelVisibility", visible => postWindowMessage("PanelVisibility", visible))
+onPortMessage("PanelVisibility", e => postWindowMessage("PanelVisibility", e))
+onPortMessage("PanelClosed", e => postWindowMessage("PanelClosed", e))
 
 once(onPortMessage, "ForceUpdate", () => postWindowMessage("ForceUpdate"))
 

--- a/packages/extension/content/content.ts
+++ b/packages/extension/content/content.ts
@@ -68,7 +68,7 @@ once(onPortMessage, "ForceUpdate", () => postWindowMessage("ForceUpdate"))
 
 onPortMessage("SetSelectedOwner", e => postWindowMessage("SetSelectedOwner", e))
 
-onPortMessage("SetSelectedSignal", e => postWindowMessage("SetSelectedSignal", e))
+onPortMessage("ToggleInspectedValue", e => postWindowMessage("ToggleInspectedValue", e))
 
 onPortMessage("HighlightElement", e => postWindowMessage("HighlightElement", e))
 

--- a/packages/extension/devtools/devtools.ts
+++ b/packages/extension/devtools/devtools.ts
@@ -6,10 +6,10 @@ log("Devtools script working.")
 
 const { onRuntimeMessage, postRuntimeMessage } = createRuntimeMessanger()
 
-postRuntimeMessage("DevtoolsScriptConnected", chrome.devtools.inspectedWindow.tabId)
-
 // Create a connection to the background page
 chrome.runtime.connect({ name: DEVTOOLS_CONNECTION_NAME })
+
+postRuntimeMessage("DevtoolsScriptConnected", chrome.devtools.inspectedWindow.tabId)
 
 let panel: chrome.devtools.panels.ExtensionPanel | undefined
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -30,7 +30,7 @@
     "@solid-primitives/context": "^0.1.1",
     "@solid-primitives/destructure": "^0.1.2",
     "@solid-primitives/immutable": "^0.1.2",
-    "@solid-primitives/keyed": "^1.0.2",
+    "@solid-primitives/keyed": "^1.1.1",
     "@solid-primitives/props": "^2.2.2",
     "@solid-primitives/rootless": "^1.1.3",
     "@solid-primitives/set": "^0.2.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -30,7 +30,7 @@
     "@solid-primitives/context": "^0.1.1",
     "@solid-primitives/destructure": "^0.1.2",
     "@solid-primitives/immutable": "^0.1.2",
-    "@solid-primitives/keyed": "^1.1.1",
+    "@solid-primitives/keyed": "^1.1.2",
     "@solid-primitives/props": "^2.2.2",
     "@solid-primitives/rootless": "^1.1.3",
     "@solid-primitives/set": "^0.2.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -30,6 +30,7 @@
     "@solid-primitives/context": "^0.1.1",
     "@solid-primitives/destructure": "^0.1.2",
     "@solid-primitives/immutable": "^0.1.2",
+    "@solid-primitives/keyed": "^1.0.2",
     "@solid-primitives/props": "^2.2.2",
     "@solid-primitives/rootless": "^1.1.3",
     "@solid-primitives/set": "^0.2.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -37,7 +37,7 @@
     "@solid-primitives/utils": "^3.0.2",
     "@vanilla-extract/css": "^1.7.3",
     "@vanilla-extract/private": "^1.0.3",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "solid-transition-group": "^0.0.10",
     "type-fest": "^2.19.0"
   },

--- a/packages/extension/src/App.tsx
+++ b/packages/extension/src/App.tsx
@@ -1,12 +1,9 @@
 import { Component, For, Show } from "solid-js"
-import { NodeType, Graph } from "@solid-devtools/shared/graph"
 import {
   StructureProvider,
-  SignalContextProvider,
   OwnerNode,
   Splitter,
   Scrollable,
-  Signals,
   OwnerPath,
   ToggleButton,
 } from "@solid-devtools/ui"
@@ -17,47 +14,10 @@ import {
   useComputationUpdatedSelector,
   useHoveredSelector,
 } from "./state/graph"
-import {
-  focused,
-  details,
-  useUpdatedSignalsSelector,
-  toggleSignalFocus,
-  setSelectedNode,
-  useOwnerSelectedSelector,
-  setHoveredElement,
-} from "./state/details"
+import { focused, details, setSelectedNode, useOwnerSelectedSelector } from "./state/details"
 import { setExtLocator, locatorEnabled } from "./state/selected"
 import * as styles from "./styles.css"
-
-const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details }) => {
-  const { name, id, type, signals, props: componentProps } = details
-  return (
-    <div class={styles.details.root}>
-      <header class={styles.details.header}>
-        <h1 class={styles.details.h1}>
-          {name} <span class={styles.details.id}>#{id}</span>
-        </h1>
-        <div class={styles.details.type}>{NodeType[type]}</div>
-      </header>
-      {componentProps && (
-        <div>
-          <pre>{JSON.stringify(componentProps, undefined, 2)}</pre>
-        </div>
-      )}
-      <div>
-        <SignalContextProvider
-          value={{
-            useUpdatedSelector: useUpdatedSignalsSelector,
-            toggleSignalFocus: toggleSignalFocus,
-            setHoveredElement,
-          }}
-        >
-          <Signals each={Object.values(signals)} />
-        </SignalContextProvider>
-      </div>
-    </div>
-  )
-}
+import Details from "./components/Details"
 
 const SelectComponent: Component<{}> = props => {
   return (
@@ -91,13 +51,7 @@ const App: Component = () => {
             onToggle={() => setSelectedNode(null)}
             side={
               <Show when={focused()}>
-                <div class={styles.details.scrollWrapper}>
-                  <Scrollable>
-                    <Show when={details()} keyed>
-                      {details => <DetailsContent details={details} />}
-                    </Show>
-                  </Scrollable>
-                </div>
+                <Details />
               </Show>
             }
           >

--- a/packages/extension/src/App.tsx
+++ b/packages/extension/src/App.tsx
@@ -1,5 +1,4 @@
 import { Component, For, Show } from "solid-js"
-import { destructure } from "@solid-primitives/destructure"
 import { NodeType, Graph } from "@solid-devtools/shared/graph"
 import {
   StructureProvider,
@@ -30,17 +29,21 @@ import {
 import { setExtLocator, locatorEnabled } from "./state/selected"
 import * as styles from "./styles.css"
 
-const DetailsContent: Component<{ details: Graph.OwnerDetails }> = props => {
-  const { name, id, type, signals } = destructure(() => props.details)
-
+const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details }) => {
+  const { name, id, type, signals, props: componentProps } = details
   return (
     <div class={styles.details.root}>
       <header class={styles.details.header}>
         <h1 class={styles.details.h1}>
-          {name()} <span class={styles.details.id}>#{id()}</span>
+          {name} <span class={styles.details.id}>#{id}</span>
         </h1>
-        <div class={styles.details.type}>{NodeType[type()]}</div>
+        <div class={styles.details.type}>{NodeType[type]}</div>
       </header>
+      {componentProps && (
+        <div>
+          <pre>{JSON.stringify(componentProps, undefined, 2)}</pre>
+        </div>
+      )}
       <div>
         <SignalContextProvider
           value={{
@@ -49,7 +52,7 @@ const DetailsContent: Component<{ details: Graph.OwnerDetails }> = props => {
             setHoveredElement,
           }}
         >
-          <Signals each={Object.values(signals())} />
+          <Signals each={Object.values(signals)} />
         </SignalContextProvider>
       </div>
     </div>
@@ -88,10 +91,12 @@ const App: Component = () => {
             onToggle={() => setSelectedNode(null)}
             side={
               <Show when={focused()}>
-                <div>
-                  <Show when={details()} keyed>
-                    {details => <DetailsContent details={details} />}
-                  </Show>
+                <div class={styles.details.scrollWrapper}>
+                  <Scrollable>
+                    <Show when={details()} keyed>
+                      {details => <DetailsContent details={details} />}
+                    </Show>
+                  </Scrollable>
                 </div>
               </Show>
             }

--- a/packages/extension/src/bridge.ts
+++ b/packages/extension/src/bridge.ts
@@ -29,13 +29,12 @@ onRuntimeMessage("ComputationUpdates", updates => {
   Graph.handleComputationsUpdate(updates.map(u => u.id))
 })
 
-onRuntimeMessage("SignalUpdates", updates => {
-  Details.handleSignalUpdates(updates)
-})
+onRuntimeMessage("SignalUpdates", Details.handleSignalUpdates)
 onRuntimeMessage("SignalValue", update => {
   // updates the signal value but without causing it to highlight
   Details.handleSignalUpdates([update], false)
 })
+onRuntimeMessage("PropsUpdate", Details.handlePropsUpdate)
 
 onRuntimeMessage("OwnerDetailsUpdate", details => {
   Details.updateDetails(details)

--- a/packages/extension/src/bridge.ts
+++ b/packages/extension/src/bridge.ts
@@ -107,7 +107,5 @@ createRoot(() => {
   })
 
   // toggle selected signals
-  Details.setOnSignalSelect((id, selected) => {
-    postRuntimeMessage("SetSelectedSignal", { id, selected })
-  })
+  Details.setOnInspectValue(payload => postRuntimeMessage("ToggleInspectedValue", payload))
 })

--- a/packages/extension/src/components/Details.tsx
+++ b/packages/extension/src/components/Details.tsx
@@ -24,7 +24,7 @@ const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details })
       {componentProps && (
         <div class={styles.props}>
           <h2>Props {componentProps.proxy && "(dynamic)"}</h2>
-          <Entries of={componentProps.value}>
+          <Entries of={componentProps.record}>
             {(name, value) => (
               <ValueNode
                 name={name}

--- a/packages/extension/src/components/Details.tsx
+++ b/packages/extension/src/components/Details.tsx
@@ -7,7 +7,7 @@ import {
   useUpdatedSignalsSelector,
   toggleSignalFocus,
   togglePropFocus,
-  setHoveredElement,
+  toggleHoveredElement,
 } from "../state/details"
 import * as styles from "./details.css"
 
@@ -29,10 +29,9 @@ const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details })
               <ValueNode
                 name={name}
                 value={value().value}
-                type={value().signal ? NodeType.Signal : null}
                 selected={value().selected}
                 onClick={() => togglePropFocus(name)}
-                // onElementHover={() => togglePropFocus(name, )}
+                onElementHover={toggleHoveredElement}
               />
             )}
           </Entries>
@@ -43,8 +42,8 @@ const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details })
         <SignalContextProvider
           value={{
             useUpdatedSelector: useUpdatedSignalsSelector,
-            toggleSignalFocus: toggleSignalFocus,
-            setHoveredElement,
+            toggleSignalFocus,
+            toggleHoveredElement,
           }}
         >
           <Signals each={Object.values(signals)} />

--- a/packages/extension/src/components/Details.tsx
+++ b/packages/extension/src/components/Details.tsx
@@ -1,5 +1,5 @@
 import { Component, Show } from "solid-js"
-import { Key } from "@solid-primitives/keyed"
+import { Entries } from "@solid-primitives/keyed"
 import { NodeType, Graph } from "@solid-devtools/shared/graph"
 import { SignalContextProvider, Scrollable, Signals, ValueNode } from "@solid-devtools/ui"
 import {
@@ -23,20 +23,16 @@ const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details })
       {componentProps && (
         <div class={styles.props}>
           <h2>Props {componentProps.proxy && "(dynamic)"}</h2>
-          <Key each={Object.entries(componentProps.value)} by={0}>
-            {keyvalue => {
-              const name = keyvalue()[0]
-              const value = () => keyvalue()[1]
-              return (
-                <ValueNode
-                  name={name}
-                  value={value().value}
-                  type={value().signal ? NodeType.Signal : null}
-                  selected={false}
-                />
-              )
-            }}
-          </Key>
+          <Entries of={componentProps.value}>
+            {(name, value) => (
+              <ValueNode
+                name={name}
+                value={value().value}
+                type={value().signal ? NodeType.Signal : null}
+                selected={false}
+              />
+            )}
+          </Entries>
         </div>
       )}
       <div>

--- a/packages/extension/src/components/Details.tsx
+++ b/packages/extension/src/components/Details.tsx
@@ -21,33 +21,37 @@ const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details })
         </h1>
         <div class={styles.type}>{NodeType[type]}</div>
       </header>
-      {componentProps && (
-        <div class={styles.props}>
-          <h2>Props {componentProps.proxy && "(dynamic)"}</h2>
-          <Entries of={componentProps.record}>
-            {(name, value) => (
-              <ValueNode
-                name={name}
-                value={value().value}
-                selected={value().selected}
-                onClick={() => togglePropFocus(name)}
-                onElementHover={toggleHoveredElement}
-              />
-            )}
-          </Entries>
+      <div class={styles.content}>
+        {componentProps && (
+          <div>
+            <h2 class={styles.h2}>
+              Props {componentProps.proxy && <span class={styles.proxy}>proxy</span>}
+            </h2>
+            <Entries of={componentProps.record}>
+              {(name, value) => (
+                <ValueNode
+                  name={name}
+                  value={value().value}
+                  selected={value().selected}
+                  onClick={() => togglePropFocus(name)}
+                  onElementHover={toggleHoveredElement}
+                />
+              )}
+            </Entries>
+          </div>
+        )}
+        <div>
+          <h2 class={styles.h2}>Signals</h2>
+          <SignalContextProvider
+            value={{
+              useUpdatedSelector: useUpdatedSignalsSelector,
+              toggleSignalFocus,
+              toggleHoveredElement,
+            }}
+          >
+            <Signals each={Object.values(signals)} />
+          </SignalContextProvider>
         </div>
-      )}
-      <div>
-        <h2>Signals</h2>
-        <SignalContextProvider
-          value={{
-            useUpdatedSelector: useUpdatedSignalsSelector,
-            toggleSignalFocus,
-            toggleHoveredElement,
-          }}
-        >
-          <Signals each={Object.values(signals)} />
-        </SignalContextProvider>
       </div>
     </div>
   )

--- a/packages/extension/src/components/Details.tsx
+++ b/packages/extension/src/components/Details.tsx
@@ -1,0 +1,68 @@
+import { Component, Show } from "solid-js"
+import { Key } from "@solid-primitives/keyed"
+import { NodeType, Graph } from "@solid-devtools/shared/graph"
+import { SignalContextProvider, Scrollable, Signals, ValueNode } from "@solid-devtools/ui"
+import {
+  details,
+  useUpdatedSignalsSelector,
+  toggleSignalFocus,
+  setHoveredElement,
+} from "../state/details"
+import * as styles from "./details.css"
+
+const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details }) => {
+  const { name, id, type, signals, props: componentProps } = details
+  return (
+    <div class={styles.root}>
+      <header class={styles.header}>
+        <h1 class={styles.h1}>
+          {name} <span class={styles.id}>#{id}</span>
+        </h1>
+        <div class={styles.type}>{NodeType[type]}</div>
+      </header>
+      {componentProps && (
+        <div class={styles.props}>
+          <h2>Props {componentProps.proxy && "(dynamic)"}</h2>
+          <Key each={Object.entries(componentProps.value)} by={0}>
+            {keyvalue => {
+              const name = keyvalue()[0]
+              const value = () => keyvalue()[1]
+              return (
+                <ValueNode
+                  name={name}
+                  value={value().value}
+                  type={value().signal ? NodeType.Signal : null}
+                  selected={false}
+                />
+              )
+            }}
+          </Key>
+        </div>
+      )}
+      <div>
+        <h2>Signals</h2>
+        <SignalContextProvider
+          value={{
+            useUpdatedSelector: useUpdatedSignalsSelector,
+            toggleSignalFocus: toggleSignalFocus,
+            setHoveredElement,
+          }}
+        >
+          <Signals each={Object.values(signals)} />
+        </SignalContextProvider>
+      </div>
+    </div>
+  )
+}
+
+export default function Details() {
+  return (
+    <div class={styles.scrollWrapper}>
+      <Scrollable>
+        <Show when={details()} keyed>
+          {details => <DetailsContent details={details} />}
+        </Show>
+      </Scrollable>
+    </div>
+  )
+}

--- a/packages/extension/src/components/Details.tsx
+++ b/packages/extension/src/components/Details.tsx
@@ -6,6 +6,7 @@ import {
   details,
   useUpdatedSignalsSelector,
   toggleSignalFocus,
+  togglePropFocus,
   setHoveredElement,
 } from "../state/details"
 import * as styles from "./details.css"
@@ -29,7 +30,9 @@ const DetailsContent: Component<{ details: Graph.OwnerDetails }> = ({ details })
                 name={name}
                 value={value().value}
                 type={value().signal ? NodeType.Signal : null}
-                selected={false}
+                selected={value().selected}
+                onClick={() => togglePropFocus(name)}
+                // onElementHover={() => togglePropFocus(name, )}
               />
             )}
           </Entries>

--- a/packages/extension/src/components/details.css.ts
+++ b/packages/extension/src/components/details.css.ts
@@ -1,0 +1,40 @@
+import { spacing, color } from "@solid-devtools/ui/theme"
+import { style } from "@vanilla-extract/css"
+
+export const scrollWrapper = style({
+  height: "100%",
+  width: "100%",
+  overflow: "hidden",
+})
+
+export const root = style({
+  padding: spacing[4],
+  paddingBottom: spacing[16],
+})
+
+export const header = style({
+  marginBottom: spacing[4],
+})
+
+export const h1 = style({
+  // TODO: typography
+  fontSize: spacing[4],
+  fontWeight: "bold",
+})
+
+export const id = style({
+  fontSize: spacing[3],
+  color: color.gray[500],
+  fontWeight: 400,
+  textTransform: "uppercase",
+})
+
+export const type = style({
+  fontSize: spacing[3],
+  color: color.gray[500],
+  fontWeight: 400,
+})
+
+export const props = style({
+  marginBottom: spacing[4],
+})

--- a/packages/extension/src/components/details.css.ts
+++ b/packages/extension/src/components/details.css.ts
@@ -1,4 +1,4 @@
-import { spacing, color } from "@solid-devtools/ui/theme"
+import { spacing, color, rounded } from "@solid-devtools/ui/theme"
 import { style } from "@vanilla-extract/css"
 
 export const scrollWrapper = style({
@@ -21,20 +21,35 @@ export const h1 = style({
   fontSize: spacing[4],
   fontWeight: "bold",
 })
-
 export const id = style({
   fontSize: spacing[3],
   color: color.gray[500],
   fontWeight: 400,
   textTransform: "uppercase",
 })
-
 export const type = style({
-  fontSize: spacing[3],
   color: color.gray[500],
   fontWeight: 400,
 })
 
-export const props = style({
-  marginBottom: spacing[4],
+export const content = style({
+  display: "flex",
+  flexDirection: "column",
+  rowGap: spacing[4],
+})
+
+export const h2 = style({
+  color: color.gray[500],
+  marginBottom: spacing[1],
+})
+
+export const proxy = style({
+  paddingRight: spacing[1],
+  paddingLeft: spacing[1],
+  backgroundColor: color.cyan[100],
+  color: color.cyan[600],
+  textTransform: "uppercase",
+  fontWeight: 700,
+  fontSize: spacing[2.5],
+  ...rounded(),
 })

--- a/packages/extension/src/styles.css.ts
+++ b/packages/extension/src/styles.css.ts
@@ -62,8 +62,14 @@ export const pathInner = style({
 })
 
 export const details = {
+  scrollWrapper: style({
+    height: "100%",
+    width: "100%",
+    overflow: "hidden",
+  }),
   root: style({
     padding: spacing[4],
+    paddingBottom: spacing[16],
   }),
   header: style({
     marginBottom: spacing[4],

--- a/packages/extension/src/styles.css.ts
+++ b/packages/extension/src/styles.css.ts
@@ -60,34 +60,3 @@ export const pathInner = style({
   borderTop: `1px solid ${color.gray[200]}`,
   backgroundColor: color.gray[50],
 })
-
-export const details = {
-  scrollWrapper: style({
-    height: "100%",
-    width: "100%",
-    overflow: "hidden",
-  }),
-  root: style({
-    padding: spacing[4],
-    paddingBottom: spacing[16],
-  }),
-  header: style({
-    marginBottom: spacing[4],
-  }),
-  h1: style({
-    // TODO: typography
-    fontSize: spacing[4],
-    fontWeight: "bold",
-  }),
-  id: style({
-    fontSize: spacing[3],
-    color: color.gray[500],
-    fontWeight: 400,
-    textTransform: "uppercase",
-  }),
-  type: style({
-    fontSize: spacing[3],
-    color: color.gray[500],
-    fontWeight: 400,
-  }),
-}

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -7,7 +7,7 @@ import manifest from "./manifest"
 import pkg from "./package.json"
 
 export default defineConfig({
-  plugins: [solidPlugin({ hot: false }), vanillaExtractPlugin(), crx({ manifest })],
+  plugins: [solidPlugin(), vanillaExtractPlugin(), crx({ manifest })],
   resolve: {
     alias: {
       // "@solid-devtools/shared": resolve(__dirname, "..", "shared", "src"),

--- a/packages/locator/package.json
+++ b/packages/locator/package.json
@@ -53,7 +53,7 @@
     "esbuild-plugin-solid": "^0.4.2",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "ts-node": "^10.9.1",
     "tsup": "^6.2.3",
     "typescript": "^4.8.2"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -54,7 +54,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "ts-node": "^10.9.1",
     "tsup": "^6.2.3",
     "typescript": "^4.8.2"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -67,7 +67,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "ts-node": "^10.9.1",
     "tsup": "^6.2.3",
     "typescript": "^4.8.2"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@solid-primitives/utils": "^3.0.2",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "solid-meta": "^0.27.5",
     "twind": "^0.16.17"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -102,7 +102,7 @@
     "@solid-primitives/event-bus": "^0.1.2",
     "@solid-primitives/immutable": "^0.1.2",
     "@solid-primitives/utils": "^3.0.2",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "ts-node": "^10.9.1",
     "type-fest": "^2.19.0"
   }

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -9,7 +9,10 @@ export interface Messages {
   SolidOnPage: string
   // devtools -> background: number is a tab id
   DevtoolsScriptConnected: number
+  /** devtools -> adapter: user switching between Solid devtools and other panel */
   PanelVisibility: boolean
+  /** devtools -> adapter: the chrome devtools got entirely closed */
+  PanelClosed: true
   ResetPanel: void
   GraphUpdate: RootsUpdates
   ComputationUpdates: ComputationUpdate[]

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -17,6 +17,8 @@ export interface Messages {
   GraphUpdate: RootsUpdates
   ComputationUpdates: ComputationUpdate[]
   SignalUpdates: SignalUpdate[]
+  /** adapter -> devtools: signal deep value */
+  SignalValue: SignalUpdate
   ForceUpdate: void
   /** devtools -> adapter: request for details of owner details opened in the side-panel */
   SetSelectedOwner: null | { rootId: NodeID; nodeId: NodeID }
@@ -24,10 +26,10 @@ export interface Messages {
   SendSelectedOwner: { rootId: NodeID; nodeId: NodeID }
   /** adapter -> devtools: send updates to the owner details */
   OwnerDetailsUpdate: Mapped.OwnerDetails
-  /** devtools -> adapter: request for signal details — subscribe or unsubscribe */
-  SetSelectedSignal: { id: NodeID; selected: boolean }
-  /** adapter -> devtools: signal deep value */
-  SignalValue: SignalUpdate
+  /** devtools -> adapter: request for signal/prop details — subscribe or unsubscribe */
+  ToggleInspectedValue:
+    | { type: "signal"; id: NodeID; selected: boolean }
+    | { type: "prop"; key: NodeID; selected: boolean }
   /** devtools -> adapter: user hovered over component/element signal in devtools panel */
   HighlightElement: { rootId: NodeID; nodeId: NodeID } | string | null
   /** adapter -> devtools: send hovered (by the locator) owner to the extension */

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -19,6 +19,9 @@ export interface Messages {
   SignalUpdates: SignalUpdate[]
   /** adapter -> devtools: signal deep value */
   SignalValue: SignalUpdate
+  /** adapter -> devtools: encoded props object */
+  PropsUpdate: Mapped.Props
+  /** devtools -> adapter: force the debugger to walk the whole tree and send it */
   ForceUpdate: void
   /** devtools -> adapter: request for details of owner details opened in the side-panel */
   SetSelectedOwner: null | { rootId: NodeID; nodeId: NodeID }
@@ -27,9 +30,7 @@ export interface Messages {
   /** adapter -> devtools: send updates to the owner details */
   OwnerDetailsUpdate: Mapped.OwnerDetails
   /** devtools -> adapter: request for signal/prop details — subscribe or unsubscribe */
-  ToggleInspectedValue:
-    | { type: "signal"; id: NodeID; selected: boolean }
-    | { type: "prop"; key: NodeID; selected: boolean }
+  ToggleInspectedValue: { type: "signal" | "prop"; id: NodeID; selected: boolean }
   /** devtools -> adapter: user hovered over component/element signal in devtools panel */
   HighlightElement: { rootId: NodeID; nodeId: NodeID } | string | null
   /** adapter -> devtools: send hovered (by the locator) owner to the extension */

--- a/packages/shared/src/graph.ts
+++ b/packages/shared/src/graph.ts
@@ -228,6 +228,7 @@ export namespace Graph {
     readonly path: Path
     readonly rawPath: NodeID[]
     readonly signals: Record<NodeID, Signal>
+    readonly props?: Mapped.OwnerDetails["props"]
     // TODO: more to come
   }
 }

--- a/packages/shared/src/graph.ts
+++ b/packages/shared/src/graph.ts
@@ -174,7 +174,7 @@ export namespace Mapped {
 
   export type Props = {
     proxy: boolean
-    record: Record<string, { signal: boolean; value: EncodedValue<boolean> }>
+    record: Record<string, EncodedValue<boolean>>
   }
 
   export interface OwnerDetails {
@@ -225,7 +225,7 @@ export namespace Graph {
 
   export type Props = {
     proxy: boolean
-    record: Record<string, { selected: boolean; signal: boolean; value: EncodedValue<boolean> }>
+    record: Record<string, { selected: boolean; value: EncodedValue<boolean> }>
   }
 
   export interface OwnerDetails {

--- a/packages/shared/src/graph.ts
+++ b/packages/shared/src/graph.ts
@@ -179,7 +179,7 @@ export namespace Mapped {
     path: NodeID[]
     props?: {
       proxy: boolean
-      value: Record<string, { signal: boolean; value: EncodedValue<false> }>
+      value: Record<string, { signal: boolean; value: EncodedValue<boolean> }>
     }
     signals: Signal[]
     /** for computations */
@@ -228,7 +228,10 @@ export namespace Graph {
     readonly path: Path
     readonly rawPath: NodeID[]
     readonly signals: Record<NodeID, Signal>
-    readonly props?: Mapped.OwnerDetails["props"]
+    readonly props?: {
+      proxy: boolean
+      value: Record<string, { selected: boolean; signal: boolean; value: EncodedValue<boolean> }>
+    }
     // TODO: more to come
   }
 }

--- a/packages/shared/src/graph.ts
+++ b/packages/shared/src/graph.ts
@@ -96,6 +96,10 @@ export namespace Solid {
     observers: Computation[] | null
   }
 
+  export interface Component extends Memo {
+    props: Record<string, unknown>
+  }
+
   export type Owner = Computation | Root
 }
 
@@ -173,6 +177,10 @@ export namespace Mapped {
     name: string
     type: NodeType
     path: NodeID[]
+    props?: {
+      proxy: boolean
+      value: Record<string, { signal: boolean; value: EncodedValue<false> }>
+    }
     signals: Signal[]
     /** for computations */
     value?: EncodedValue

--- a/packages/shared/src/graph.ts
+++ b/packages/shared/src/graph.ts
@@ -172,15 +172,17 @@ export namespace Mapped {
     element: Many<HTMLElement>
   }
 
+  export type Props = {
+    proxy: boolean
+    record: Record<string, { signal: boolean; value: EncodedValue<boolean> }>
+  }
+
   export interface OwnerDetails {
     id: NodeID
     name: string
     type: NodeType
     path: NodeID[]
-    props?: {
-      proxy: boolean
-      value: Record<string, { signal: boolean; value: EncodedValue<boolean> }>
-    }
+    props?: Props
     signals: Signal[]
     /** for computations */
     value?: EncodedValue
@@ -221,6 +223,11 @@ export namespace Graph {
 
   export type Path = (Owner | typeof NOTFOUND)[]
 
+  export type Props = {
+    proxy: boolean
+    record: Record<string, { selected: boolean; signal: boolean; value: EncodedValue<boolean> }>
+  }
+
   export interface OwnerDetails {
     readonly id: NodeID
     readonly name: string
@@ -228,10 +235,7 @@ export namespace Graph {
     readonly path: Path
     readonly rawPath: NodeID[]
     readonly signals: Record<NodeID, Signal>
-    readonly props?: {
-      proxy: boolean
-      value: Record<string, { selected: boolean; signal: boolean; value: EncodedValue<boolean> }>
-    }
+    readonly props?: Props
     // TODO: more to come
   }
 }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -3,6 +3,11 @@ const getLogLabel = () => [
   "color: #fff; background: #2c4f7c; padding: 1px 4px;",
 ]
 
+export function info<T>(data: T): T {
+  console.info(...getLogLabel(), data)
+  return data
+}
+
 export function log(...args: any[]): void {
   console.log(...getLogLabel(), ...args)
 }

--- a/packages/shared/test/serialise.test.ts
+++ b/packages/shared/test/serialise.test.ts
@@ -5,6 +5,7 @@ import {
   NAN,
   encodeValue,
   EncodedValue,
+  ElementMap,
 } from "../src/serialize"
 
 const _testFunction = () => {}
@@ -167,7 +168,7 @@ describe("save elements to a map", () => {
     ],
   ]
 
-  const map: Record<number, HTMLElement> = {}
+  const map = new ElementMap()
   for (const [testName, value, expectation] of elMapExpectations) {
     test(testName, () => {
       const s = encodeValue(value, true, map)
@@ -176,9 +177,8 @@ describe("save elements to a map", () => {
     })
   }
   test("map containing correct values", () => {
-    expect(Object.keys(map).length).toBe(3)
-    expect(map[0]).toBe(div1)
-    expect(map[1]).toBe(a1)
-    expect(map[2]).toBe(div2)
+    expect(map.get("0")).toBe(div1)
+    expect(map.get("1")).toBe(a1)
+    expect(map.get("2")).toBe(div2)
   })
 })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -82,7 +82,7 @@
     "@solid-primitives/cursor": "^0.0.100",
     "@solid-primitives/event-listener": "^2.2.2",
     "@solid-primitives/keyboard": "^1.0.2",
-    "@solid-primitives/keyed": "^1.1.1",
+    "@solid-primitives/keyed": "^1.1.2",
     "@solid-primitives/props": "^2.2.2",
     "@solid-primitives/resize-observer": "^2.0.4",
     "@solid-primitives/timer": "^1.3.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -82,7 +82,7 @@
     "@solid-primitives/cursor": "^0.0.100",
     "@solid-primitives/event-listener": "^2.2.2",
     "@solid-primitives/keyboard": "^1.0.2",
-    "@solid-primitives/keyed": "^1.0.2",
+    "@solid-primitives/keyed": "^1.1.1",
     "@solid-primitives/props": "^2.2.2",
     "@solid-primitives/resize-observer": "^2.0.4",
     "@solid-primitives/timer": "^1.3.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -69,7 +69,7 @@
     "@vanilla-extract/esbuild-plugin": "^2.1.0",
     "esbuild": "^0.14.54",
     "esbuild-plugin-solid": "^0.4.2",
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "tsup": "^6.2.3",
     "typescript": "^4.8.2"
   },

--- a/packages/ui/src/components/signal/SignalNode.css.ts
+++ b/packages/ui/src/components/signal/SignalNode.css.ts
@@ -11,9 +11,6 @@ export const Signals = {
     display: "flex",
     flexDirection: "column",
     gap: RowGap,
-    fontFamily: theme.font.mono,
-    color: color.gray[800],
-    fontWeight: 600,
   }),
 }
 
@@ -32,6 +29,9 @@ export const ValueRow = {
         [valueRowHighlight.bgColorVar]: color.gray[300],
         [valueRowHighlight.bgOpacityVar]: "0",
       },
+      fontFamily: theme.font.mono,
+      color: color.gray[800],
+      fontWeight: 600,
     },
   ]),
   containerFocused: style({

--- a/packages/ui/src/components/signal/SignalNode.tsx
+++ b/packages/ui/src/components/signal/SignalNode.tsx
@@ -9,7 +9,6 @@ import {
   Match,
   onCleanup,
   ParentComponent,
-  Setter,
   Show,
   splitProps,
   Switch,
@@ -66,6 +65,9 @@ const BooleanValuePreview: ValueComponent<ValueType.Boolean> = props => (
 const FunctionValuePreview: ValueComponent<ValueType.Function> = props => (
   <span class={styles.ValueFunction}>{props.value ? `f ${props.value}()` : "function()"}</span>
 )
+const GetterValuePreview: ValueComponent<ValueType.Getter> = props => (
+  <span class={styles.ValueFunction}>get {props.value}()</span>
+)
 
 const NullableValuePreview: Component<{ value: null | undefined }> = props => (
   <span class={styles.Nullable}>{props.value === null ? "null" : "undefined"}</span>
@@ -79,9 +81,9 @@ const InstanceValuePreview: ValueComponent<ValueType.Instance> = props => (
   <span class={styles.baseValue}>{props.value}</span>
 )
 
-export type OnElementHover = (elementId: NodeID, hovered: boolean) => void
+export type ToggleElementHover = (elementId: NodeID, hovered?: boolean) => void
 
-const ElementHoverContext = createContext<OnElementHover>()
+const ElementHoverContext = createContext<ToggleElementHover>()
 
 const ElementValuePreview: ValueComponent<ValueType.Element> = props => {
   const onHover = useContext(ElementHoverContext)
@@ -192,6 +194,8 @@ const ValuePreview: Component<{ value: EncodedValue<boolean> }> = props =>
         return <ObjectValuePreview {...props.value} />
       case ValueType.Function:
         return <FunctionValuePreview value={props.value.value} />
+      case ValueType.Getter:
+        return <GetterValuePreview value={props.value.value} />
       case ValueType.Null:
         return <NullableValuePreview value={null} />
       case ValueType.Undefined:
@@ -287,7 +291,7 @@ export const ValueNode: Component<{
   selected: boolean
   updated?: boolean
   onClick?: VoidFunction
-  onElementHover?: OnElementHover
+  onElementHover?: ToggleElementHover
 }> = props => {
   return (
     <ValueRow selected={props.selected} onClick={props.onClick}>
@@ -306,7 +310,7 @@ export const ValueNode: Component<{
 export type SignalContextState = {
   useUpdatedSelector: (id: NodeID) => Accessor<boolean>
   toggleSignalFocus: (signal: NodeID, focused?: boolean) => void
-  setHoveredElement: Setter<string | null>
+  toggleHoveredElement: ToggleElementHover
 }
 
 const SignalContext = createContext<SignalContextState>()
@@ -321,7 +325,7 @@ const useSignalContext = (): SignalContextState => {
 
 export const SignalNode: Component<{ signal: Graph.Signal }> = ({ signal }) => {
   const { type, id, name } = signal
-  const { useUpdatedSelector, toggleSignalFocus, setHoveredElement } = useSignalContext()
+  const { useUpdatedSelector, toggleSignalFocus, toggleHoveredElement } = useSignalContext()
 
   const isUpdated = useUpdatedSelector(id)
 
@@ -333,7 +337,7 @@ export const SignalNode: Component<{ signal: Graph.Signal }> = ({ signal }) => {
       selected={signal.selected}
       updated={isUpdated()}
       onClick={() => toggleSignalFocus(id)}
-      onElementHover={(id, hovered) => setHoveredElement(hovered ? id : p => (p === id ? null : p))}
+      onElementHover={toggleHoveredElement}
     />
   )
 }

--- a/packages/ui/src/components/signal/SignalNode.tsx
+++ b/packages/ui/src/components/signal/SignalNode.tsx
@@ -15,7 +15,7 @@ import {
   Switch,
   useContext,
 } from "solid-js"
-import { Key } from "@solid-primitives/keyed"
+import { Entries } from "@solid-primitives/keyed"
 import { Graph, NodeID, NodeType } from "@solid-devtools/shared/graph"
 import {
   EncodedValue,
@@ -138,46 +138,40 @@ const CollapsableObjectPreview: Component<{
     | EncodedValueOf<ValueType.Array, true>["children"]
 }> = props => (
   <ul class={styles.collapsable.list}>
-    <Key each={Object.entries(props.value)} by={0}>
-      {keyvalue => {
-        // TODO: is <Key> necessary here? the values should be reconciled by the key anyway
-        // key will be static, because <Key> is using it as a key
-        const key = keyvalue()[0]
-        const value = () => keyvalue()[1]
-        return (
-          <Show
-            when={value().type === ValueType.Object || value().type === ValueType.Array}
-            fallback={
-              <ValueRow>
+    <Entries of={props.value}>
+      {(key, value) => (
+        <Show
+          when={value().type === ValueType.Object || value().type === ValueType.Array}
+          fallback={
+            <ValueRow>
+              <ValueName>{key}</ValueName>
+              <ValuePreview value={value()} />
+            </ValueRow>
+          }
+        >
+          {() => {
+            const [extended, setExtended] = createSignal(false)
+            return (
+              <ValueRow
+                selected={false}
+                onClick={e => {
+                  e.stopPropagation()
+                  setExtended(p => !p)
+                }}
+              >
                 <ValueName>{key}</ValueName>
-                <ValuePreview value={value()} />
+                <ObjectValuePreview
+                  {...(value() as
+                    | EncodedValueOf<ValueType.Object, true>
+                    | EncodedValueOf<ValueType.Array, true>)}
+                  extended={extended()}
+                />
               </ValueRow>
-            }
-          >
-            {() => {
-              const [extended, setExtended] = createSignal(false)
-              return (
-                <ValueRow
-                  selected={false}
-                  onClick={e => {
-                    e.stopPropagation()
-                    setExtended(p => !p)
-                  }}
-                >
-                  <ValueName>{key}</ValueName>
-                  <ObjectValuePreview
-                    {...(value() as
-                      | EncodedValueOf<ValueType.Object, true>
-                      | EncodedValueOf<ValueType.Array, true>)}
-                    extended={extended()}
-                  />
-                </ValueRow>
-              )
-            }}
-          </Show>
-        )
-      }}
-    </Key>
+            )
+          }}
+        </Show>
+      )}
+    </Entries>
   </ul>
 )
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,10 +1,7 @@
 import "./styles.css"
 
-export * from "./theme"
-
 export { OwnerNode } from "./components/owner/OwnerNode"
-export { SignalNode, Signals, SignalContextProvider } from "./components/signal/SignalNode"
-export type { SignalContextState } from "./components/signal/SignalNode"
+export * from "./components/signal/SignalNode"
 export { Splitter } from "./components/splitter/Splitter"
 export { Scrollable } from "./components/scrollable/Scrollable"
 export { Skeleton } from "./components/loading/Skeleton"

--- a/playgrounds/clock/package.json
+++ b/playgrounds/clock/package.json
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "solid-devtools": "^0.15.0",
-    "solid-js": "^1.5.4"
+    "solid-js": "^1.5.5"
   }
 }

--- a/playgrounds/sandbox/package.json
+++ b/playgrounds/sandbox/package.json
@@ -20,6 +20,6 @@
     "@solid-devtools/logger": "^0.4.5",
     "@solid-primitives/timer": "^1.3.2",
     "solid-devtools": "^0.15.0",
-    "solid-js": "^1.5.4"
+    "solid-js": "^1.5.5"
   }
 }

--- a/playgrounds/sandbox/src/Todos.tsx
+++ b/playgrounds/sandbox/src/Todos.tsx
@@ -1,8 +1,6 @@
-import { createEffect, createSignal, batch, For, Component } from "solid-js"
-import { $RAW, reconcile, unwrap } from "solid-js/store"
+import { createEffect, createSignal, batch, For, Component, getOwner } from "solid-js"
 import { createStore, Store, SetStoreFunction } from "solid-js/store"
-import { debugProps } from "@solid-devtools/logger"
-// import { makeStoreObserver } from "@solid-devtools/debugger"
+// import { isSolidMemo } from "@solid-devtools/debugger"
 
 export function createLocalStore<T extends object>(
   name: string,
@@ -27,6 +25,8 @@ const Todo: Component<{
   onUpdate: (value: string) => void
   onRemove: VoidFunction
 }> = props => {
+  // console.log(isSolidMemo(getOwner()!.owner))
+
   // debugProps(props)
 
   return (

--- a/playgrounds/start/package.json
+++ b/playgrounds/start/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@solidjs/meta": "^0.28.0",
     "@solidjs/router": "^0.4.3",
-    "solid-js": "1.5.1",
+    "solid-js": "1.5.5",
     "solid-start": "0.1.0-alpha.99",
     "undici": "^5.10.0"
   },

--- a/playgrounds/todomvc/package.json
+++ b/playgrounds/todomvc/package.json
@@ -33,7 +33,7 @@
     "npm": ">=7.20.1"
   },
   "dependencies": {
-    "solid-js": "^1.5.4",
+    "solid-js": "^1.5.5",
     "todomvc-app-css": "^2.4.2",
     "todomvc-common": "^1.0.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
       esbuild-plugin-solid: ^0.4.2
       object-observer: ^5.0.4
       prettier: 2.7.0
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       taze: ^0.8.0
       ts-jest: ^28.0.8
       tsup: ^6.2.3
@@ -30,10 +30,10 @@ importers:
       '@types/node': 17.0.45
       babel-preset-solid: 1.5.4_@babel+core@7.18.13
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2_kdtxu7zkztxu5bgafyqjgjsfvy
+      esbuild-plugin-solid: 0.4.2_dnb7jb4m7l53iwnykiyaipi6jq
       object-observer: 5.0.4
       prettier: 2.7.0
-      solid-js: 1.5.4
+      solid-js: 1.5.5
       taze: 0.8.0
       ts-jest: 28.0.8_pih44xxgoeoz2opfqmd7wnmree
       tsup: 6.2.3_typescript@4.8.2
@@ -54,29 +54,29 @@ importers:
       jest: ^28.1.3
       jest-environment-jsdom: ^28.1.3
       object-observer: ^5.0.4
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       ts-node: ^10.9.1
       tsup: ^6.2.3
       type-fest: ^2.19.0
       typescript: ^4.8.2
     dependencies:
       '@solid-devtools/shared': link:../shared
-      '@solid-primitives/event-bus': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/memo': 0.3.0_solid-js@1.5.4
-      '@solid-primitives/refs': 0.3.2_solid-js@1.5.4
-      '@solid-primitives/scheduled': 1.0.1_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
+      '@solid-primitives/event-bus': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/memo': 0.3.0_solid-js@1.5.5
+      '@solid-primitives/refs': 0.3.2_solid-js@1.5.5
+      '@solid-primitives/scheduled': 1.0.1_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
       object-observer: 5.0.4
       type-fest: 2.19.0
     optionalDependencies:
       '@solid-devtools/transform': link:../transform
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
+      jest: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
       jest-environment-jsdom: 28.1.3
-      solid-js: 1.5.4
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
+      solid-js: 1.5.5
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -86,7 +86,7 @@ importers:
       '@solid-devtools/locator': workspace:^0.15.1
       '@solid-devtools/shared': workspace:^0.7.3
       '@solid-primitives/utils': ^3.0.2
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       tsup: ^6.2.3
       type-fest: ^2.19.0
       typescript: ^4.8.2
@@ -94,10 +94,10 @@ importers:
       '@solid-devtools/debugger': link:../debugger
       '@solid-devtools/locator': link:../locator
       '@solid-devtools/shared': link:../shared
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
       type-fest: 2.19.0
     devDependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
       tsup: 6.2.3_typescript@4.8.2
       typescript: 4.8.2
 
@@ -121,7 +121,7 @@ importers:
       '@vanilla-extract/vite-plugin': ^3.3.1
       esbuild-plugin-solid: ^0.4.2
       rimraf: ^3.0.2
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       solid-transition-group: ^0.0.10
       type-fest: ^2.19.0
       typescript: ^4.8.2
@@ -131,29 +131,29 @@ importers:
     dependencies:
       '@solid-devtools/shared': link:../shared
       '@solid-devtools/ui': link:../ui
-      '@solid-primitives/context': 0.1.1_solid-js@1.5.4
-      '@solid-primitives/destructure': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/keyed': 1.1.2_solid-js@1.5.4
-      '@solid-primitives/props': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.4
-      '@solid-primitives/set': 0.2.2_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
+      '@solid-primitives/context': 0.1.1_solid-js@1.5.5
+      '@solid-primitives/destructure': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/keyed': 1.1.2_solid-js@1.5.5
+      '@solid-primitives/props': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.5
+      '@solid-primitives/set': 0.2.2_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
       '@vanilla-extract/css': 1.7.3
       '@vanilla-extract/private': 1.0.3
-      solid-js: 1.5.4
-      solid-transition-group: 0.0.10_solid-js@1.5.4
+      solid-js: 1.5.5
+      solid-transition-group: 0.0.10_solid-js@1.5.5
       type-fest: 2.19.0
     devDependencies:
       '@crxjs/vite-plugin': 1.0.14_vite@3.0.9
       '@solid-devtools/ext-adapter': link:../ext-adapter
       '@types/chrome': 0.0.193
       '@vanilla-extract/vite-plugin': 3.3.1_vite@3.0.9
-      esbuild-plugin-solid: 0.4.2_bwcvipldrmzlcczfdyw74a3qbi
+      esbuild-plugin-solid: 0.4.2_6ptba4h3py425bf34khwc276eu
       rimraf: 3.0.2
       typescript: 4.8.2
       vite: 3.0.9
-      vite-plugin-solid: 2.3.0_solid-js@1.5.4+vite@3.0.9
+      vite-plugin-solid: 2.3.0_solid-js@1.5.5+vite@3.0.9
       zip-a-folder: 1.1.5
 
   packages/locator:
@@ -175,20 +175,20 @@ importers:
       jest: ^28.1.3
       jest-environment-jsdom: ^28.1.3
       motion: ^10.14.1
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       ts-node: ^10.9.1
       tsup: ^6.2.3
       typescript: ^4.8.2
     dependencies:
       '@solid-devtools/debugger': link:../debugger
       '@solid-devtools/shared': link:../shared
-      '@solid-primitives/bounds': 0.0.101_solid-js@1.5.4
-      '@solid-primitives/cursor': 0.0.100_solid-js@1.5.4
-      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/keyboard': 1.0.2_solid-js@1.5.4
-      '@solid-primitives/platform': 0.0.100_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
+      '@solid-primitives/bounds': 0.0.101_solid-js@1.5.5
+      '@solid-primitives/cursor': 0.0.100_solid-js@1.5.5
+      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/keyboard': 1.0.2_solid-js@1.5.5
+      '@solid-primitives/platform': 0.0.100_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
       clsx: 1.2.1
       motion: 10.14.1
     optionalDependencies:
@@ -196,11 +196,11 @@ importers:
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2_kdtxu7zkztxu5bgafyqjgjsfvy
-      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
+      esbuild-plugin-solid: 0.4.2_dnb7jb4m7l53iwnykiyaipi6jq
+      jest: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
       jest-environment-jsdom: 28.1.3
-      solid-js: 1.5.4
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
+      solid-js: 1.5.5
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -212,20 +212,20 @@ importers:
       '@testing-library/jest-dom': ^5.16.5
       jest: ^28.1.3
       jest-environment-jsdom: ^28.1.3
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       ts-node: ^10.9.1
       tsup: ^6.2.3
       typescript: ^4.8.2
     dependencies:
       '@solid-devtools/debugger': link:../debugger
       '@solid-devtools/shared': link:../shared
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
+      jest: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
       jest-environment-jsdom: 28.1.3
-      solid-js: 1.5.4
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
+      solid-js: 1.5.5
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -238,7 +238,7 @@ importers:
       '@testing-library/jest-dom': ^5.16.5
       jest: ^28.1.3
       jest-environment-jsdom: ^28.1.3
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       ts-node: ^10.9.1
       tsup: ^6.2.3
       typescript: ^4.8.2
@@ -249,10 +249,10 @@ importers:
       '@solid-devtools/transform': link:../transform
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
+      jest: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
       jest-environment-jsdom: 28.1.3
-      solid-js: 1.5.4
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
+      solid-js: 1.5.5
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -263,15 +263,15 @@ importers:
       rimraf: ^3.0.2
       rollup: ^2.79.0
       rollup-preset-solid: ^1.4.0
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       solid-meta: ^0.27.5
       twind: ^0.16.17
       typescript: ^4.8.2
       watchlist: ^0.3.1
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
-      solid-meta: 0.27.5_solid-js@1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
+      solid-meta: 0.27.5_solid-js@1.5.5
       twind: 0.16.17_typescript@4.8.2
     devDependencies:
       '@rollup/plugin-alias': 3.1.9_rollup@2.79.0
@@ -289,21 +289,21 @@ importers:
       '@testing-library/jest-dom': ^5.16.5
       jest: ^28.1.3
       jest-environment-jsdom: ^28.1.3
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       ts-node: ^10.9.1
       tsup: ^6.2.3
       type-fest: ^2.19.0
       typescript: ^4.8.2
     dependencies:
-      '@solid-primitives/event-bus': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
+      '@solid-primitives/event-bus': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
       type-fest: 2.19.0
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
+      jest: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
       jest-environment-jsdom: 28.1.3
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
@@ -369,53 +369,53 @@ importers:
       csstype: ^3.1.0
       esbuild: ^0.14.54
       esbuild-plugin-solid: ^0.4.2
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       solid-transition-group: ^0.0.11
       tsup: ^6.2.3
       typescript: ^4.8.2
     dependencies:
-      '@otonashixav/solid-flip': 0.10.5_solid-js@1.5.4
-      '@solid-aria/button': 0.1.3_solid-js@1.5.4
-      '@solid-aria/interactions': 0.1.4_solid-js@1.5.4
+      '@otonashixav/solid-flip': 0.10.5_solid-js@1.5.5
+      '@solid-aria/button': 0.1.3_solid-js@1.5.5
+      '@solid-aria/interactions': 0.1.4_solid-js@1.5.5
       '@solid-devtools/shared': link:../shared
-      '@solid-primitives/bounds': 0.0.102_solid-js@1.5.4
-      '@solid-primitives/cursor': 0.0.100_solid-js@1.5.4
-      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/keyboard': 1.0.2_solid-js@1.5.4
-      '@solid-primitives/keyed': 1.1.2_solid-js@1.5.4
-      '@solid-primitives/props': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.4
-      '@solid-primitives/timer': 1.3.2_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
+      '@solid-primitives/bounds': 0.0.102_solid-js@1.5.5
+      '@solid-primitives/cursor': 0.0.100_solid-js@1.5.5
+      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/keyboard': 1.0.2_solid-js@1.5.5
+      '@solid-primitives/keyed': 1.1.2_solid-js@1.5.5
+      '@solid-primitives/props': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.5
+      '@solid-primitives/timer': 1.3.2_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
       '@vanilla-extract/css': 1.7.3
       '@vanilla-extract/dynamic': 2.0.2
       '@vanilla-extract/private': 1.0.3
       clsx: 1.2.1
       csstype: 3.1.0
-      solid-transition-group: 0.0.11_solid-js@1.5.4
+      solid-transition-group: 0.0.11_solid-js@1.5.5
     devDependencies:
       '@solid-devtools/transform': link:../transform
       '@vanilla-extract/esbuild-plugin': 2.1.0
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2_kdtxu7zkztxu5bgafyqjgjsfvy
-      solid-js: 1.5.4
+      esbuild-plugin-solid: 0.4.2_dnb7jb4m7l53iwnykiyaipi6jq
+      solid-js: 1.5.5
       tsup: 6.2.3_typescript@4.8.2
       typescript: 4.8.2
 
   playgrounds/clock:
     specifiers:
       solid-devtools: ^0.15.0
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       typescript: ^4.8.2
       vite: ^3.0.9
       vite-plugin-solid: ^2.3.0
     dependencies:
       solid-devtools: link:../../packages/main
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     devDependencies:
       typescript: 4.8.2
       vite: 3.0.9
-      vite-plugin-solid: 2.3.0_solid-js@1.5.4+vite@3.0.9
+      vite-plugin-solid: 2.3.0_solid-js@1.5.5+vite@3.0.9
 
   playgrounds/sandbox:
     specifiers:
@@ -423,20 +423,20 @@ importers:
       '@solid-devtools/transform': ^0.7.2
       '@solid-primitives/timer': ^1.3.2
       solid-devtools: ^0.15.0
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       typescript: ^4.8.2
       vite: ^3.0.9
       vite-plugin-solid: ^2.3.0
     dependencies:
       '@solid-devtools/logger': link:../../packages/logger
-      '@solid-primitives/timer': 1.3.2_solid-js@1.5.4
+      '@solid-primitives/timer': 1.3.2_solid-js@1.5.5
       solid-devtools: link:../../packages/main
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     devDependencies:
       '@solid-devtools/transform': link:../../packages/transform
       typescript: 4.8.2
       vite: 3.0.9
-      vite-plugin-solid: 2.3.0_solid-js@1.5.4+vite@3.0.9
+      vite-plugin-solid: 2.3.0_solid-js@1.5.5+vite@3.0.9
 
   playgrounds/start:
     specifiers:
@@ -444,17 +444,17 @@ importers:
       '@solidjs/meta': ^0.28.0
       '@solidjs/router': ^0.4.3
       solid-devtools: ^0.15.0
-      solid-js: 1.5.1
+      solid-js: 1.5.5
       solid-start: 0.1.0-alpha.99
       solid-start-node: 0.1.0-alpha.99
       typescript: ^4.8.2
       undici: ^5.10.0
       vite: ^3.0.9
     dependencies:
-      '@solidjs/meta': 0.28.0_solid-js@1.5.1
-      '@solidjs/router': 0.4.3_solid-js@1.5.1
-      solid-js: 1.5.1
-      solid-start: 0.1.0-alpha.99_zbd6upuqjs243od46l5stqtfw4
+      '@solidjs/meta': 0.28.0_solid-js@1.5.5
+      '@solidjs/router': 0.4.3_solid-js@1.5.5
+      solid-js: 1.5.5
+      solid-start: 0.1.0-alpha.99_2fe554iznd4cemlxxayhcxqy3q
       undici: 5.10.0
     devDependencies:
       '@solid-devtools/transform': link:../../packages/transform
@@ -465,20 +465,20 @@ importers:
 
   playgrounds/todomvc:
     specifiers:
-      solid-js: ^1.5.4
+      solid-js: ^1.5.5
       todomvc-app-css: ^2.4.2
       todomvc-common: ^1.0.5
       typescript: ^4.8.2
       vite: ^3.0.9
       vite-plugin-solid: ^2.3.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
       todomvc-app-css: 2.4.2
       todomvc-common: 1.0.5
     devDependencies:
       typescript: 4.8.2
       vite: 3.0.9
-      vite-plugin-solid: 2.3.0_solid-js@1.5.4+vite@3.0.9
+      vite-plugin-solid: 2.3.0_solid-js@1.5.5+vite@3.0.9
 
 packages:
 
@@ -3900,12 +3900,12 @@ packages:
       - supports-color
     dev: true
 
-  /@otonashixav/solid-flip/0.10.5_solid-js@1.5.4:
+  /@otonashixav/solid-flip/0.10.5_solid-js@1.5.5:
     resolution: {integrity: sha512-Tb2n9lzuktteqm26KJ1yH9NJsY2SbgNCHWnCOAKjEWBfGfw4j31vJVG1+k11WmgP2g9YzuyS8Skr7HsFntXZWA==}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
   /@polka/url/1.0.0-next.21:
@@ -4051,294 +4051,294 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: true
 
-  /@solid-aria/button/0.1.3_solid-js@1.5.4:
+  /@solid-aria/button/0.1.3_solid-js@1.5.5:
     resolution: {integrity: sha512-gN7/d5YkHAbQPhzBVbNNp9grf9w+mxFRulbmeXjp61hFNLOJRDcdMPCri5MmfUJ8D2BwefcyHvCGTCc62Ua23A==}
     peerDependencies:
       solid-js: ^1.4.4
     dependencies:
-      '@solid-aria/focus': 0.1.4_solid-js@1.5.4
-      '@solid-aria/interactions': 0.1.4_solid-js@1.5.4
-      '@solid-aria/toggle': 0.1.3_solid-js@1.5.4
-      '@solid-aria/types': 0.1.3_solid-js@1.5.4
-      '@solid-aria/utils': 0.2.0_solid-js@1.5.4
-      '@solid-primitives/props': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/utils': 2.1.1_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-aria/focus': 0.1.4_solid-js@1.5.5
+      '@solid-aria/interactions': 0.1.4_solid-js@1.5.5
+      '@solid-aria/toggle': 0.1.3_solid-js@1.5.5
+      '@solid-aria/types': 0.1.3_solid-js@1.5.5
+      '@solid-aria/utils': 0.2.0_solid-js@1.5.5
+      '@solid-primitives/props': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/utils': 2.1.1_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-aria/focus/0.1.4_solid-js@1.5.4:
+  /@solid-aria/focus/0.1.4_solid-js@1.5.5:
     resolution: {integrity: sha512-yX/BbN97s7ascNJu0yB+p1bx48U0NOOWw7+TYlGcAfFGc2HMNpIxG5OdhWGUoz8D9Tp5ELEgWgN3d4dAf7Hk9Q==}
     peerDependencies:
       solid-js: ^1.4.4
     dependencies:
-      '@solid-aria/interactions': 0.1.4_solid-js@1.5.4
-      '@solid-aria/types': 0.1.3_solid-js@1.5.4
-      '@solid-aria/utils': 0.2.0_solid-js@1.5.4
-      '@solid-primitives/props': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/utils': 2.1.1_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-aria/interactions': 0.1.4_solid-js@1.5.5
+      '@solid-aria/types': 0.1.3_solid-js@1.5.5
+      '@solid-aria/utils': 0.2.0_solid-js@1.5.5
+      '@solid-primitives/props': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/utils': 2.1.1_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-aria/interactions/0.1.4_solid-js@1.5.4:
+  /@solid-aria/interactions/0.1.4_solid-js@1.5.5:
     resolution: {integrity: sha512-gVJWJTX51mZfURoak39mxCo/vUQl8UInctJBlT2nIc3VQrTPL4ekOV6czrvTffpduoWgXeuf61+Dabc7b920lQ==}
     peerDependencies:
       solid-js: ^1.4.4
     dependencies:
-      '@solid-aria/types': 0.1.3_solid-js@1.5.4
-      '@solid-aria/utils': 0.2.0_solid-js@1.5.4
-      '@solid-primitives/platform': 0.0.100_solid-js@1.5.4
-      '@solid-primitives/props': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/utils': 2.1.1_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-aria/types': 0.1.3_solid-js@1.5.5
+      '@solid-aria/utils': 0.2.0_solid-js@1.5.5
+      '@solid-primitives/platform': 0.0.100_solid-js@1.5.5
+      '@solid-primitives/props': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/utils': 2.1.1_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-aria/toggle/0.1.3_solid-js@1.5.4:
+  /@solid-aria/toggle/0.1.3_solid-js@1.5.5:
     resolution: {integrity: sha512-ZVRhY+Te8XBFFcumuu2J92LBntlmV6ss/6fNkDfhvr4LV42VB1goRZvPJk8rqakyR3JkQBTnQuxt7idrqqaxgA==}
     peerDependencies:
       solid-js: ^1.4.4
     dependencies:
-      '@solid-aria/focus': 0.1.4_solid-js@1.5.4
-      '@solid-aria/interactions': 0.1.4_solid-js@1.5.4
-      '@solid-aria/types': 0.1.3_solid-js@1.5.4
-      '@solid-aria/utils': 0.2.0_solid-js@1.5.4
-      '@solid-primitives/props': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/utils': 2.1.1_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-aria/focus': 0.1.4_solid-js@1.5.5
+      '@solid-aria/interactions': 0.1.4_solid-js@1.5.5
+      '@solid-aria/types': 0.1.3_solid-js@1.5.5
+      '@solid-aria/utils': 0.2.0_solid-js@1.5.5
+      '@solid-primitives/props': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/utils': 2.1.1_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-aria/types/0.1.3_solid-js@1.5.4:
+  /@solid-aria/types/0.1.3_solid-js@1.5.5:
     resolution: {integrity: sha512-pl/g1pS+wNKRePxyDJ9dx3Sj460IL8R2gcEDJWr+v749OQv3dpnHHpLktrIkVnMZ1vW7lxXIZDfoXepkVChYFA==}
     peerDependencies:
       solid-js: ^1.4.4
     dependencies:
-      '@solid-primitives/utils': 2.1.1_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/utils': 2.1.1_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-aria/utils/0.2.0_solid-js@1.5.4:
+  /@solid-aria/utils/0.2.0_solid-js@1.5.5:
     resolution: {integrity: sha512-lQJLsgcb6Ji1NhP/H49/L769v0yCKldzIONwr+6zTHNcm7iw0vLzG5F4mRYicGfIbEEekyDqn8zwsOArVOeeBg==}
     peerDependencies:
       solid-js: ^1.4.4
     dependencies:
-      '@solid-aria/types': 0.1.3_solid-js@1.5.4
-      '@solid-primitives/utils': 2.1.1_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-aria/types': 0.1.3_solid-js@1.5.5
+      '@solid-primitives/utils': 2.1.1_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/bounds/0.0.101_solid-js@1.5.4:
+  /@solid-primitives/bounds/0.0.101_solid-js@1.5.5:
     resolution: {integrity: sha512-lxn5iwueU2xMEGteJoTcaIuGEAfAQvKcYKImJ3HSjO3Qu3iFERfCU1Oi5VBsIfLk8JA4582/ISuAcDiGTAVSCw==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/bounds/0.0.102_solid-js@1.5.4:
+  /@solid-primitives/bounds/0.0.102_solid-js@1.5.5:
     resolution: {integrity: sha512-bno5qplSGNxDAAdo6qGrT7e4i0HkFc3P4LFVlIU8yGVvfamLGsNva6Fjl/gs71fDunSk7T81jlReaHCc0O4wlQ==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/context/0.1.1_solid-js@1.5.4:
+  /@solid-primitives/context/0.1.1_solid-js@1.5.5:
     resolution: {integrity: sha512-foqL7Nae8K/7yKk1CZLc83D07wH9R0JiQ/ntpMB+AyY7GBuFaKAUkMUS3NnPucoA7/wqnsZXtKPd1ohlH5NORA==}
     peerDependencies:
       solid-js: ^1.3.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/cursor/0.0.100_solid-js@1.5.4:
+  /@solid-primitives/cursor/0.0.100_solid-js@1.5.5:
     resolution: {integrity: sha512-XstEQqblHeUfnBoU+wtpx1cfrU+XR2rubyIdO7ARPW8EKHwtO8fRKQsyeyzi9neFl1eCmuy/TZaKs44JH/vSeg==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/destructure/0.1.2_solid-js@1.5.4:
+  /@solid-primitives/destructure/0.1.2_solid-js@1.5.5:
     resolution: {integrity: sha512-Is/o14Sj6LUS9/yzsTsnp0BQ+wWMHhEhzUAp8FXgFiirHuzfZVDngvRd0a4PezDw5kl8ziyV7vBimDt5vuKPhw==}
     peerDependencies:
       solid-js: ^1.3.0
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/event-bus/0.1.2_solid-js@1.5.4:
+  /@solid-primitives/event-bus/0.1.2_solid-js@1.5.5:
     resolution: {integrity: sha512-W79mwPqTqflFZppNKyKG6IW/zKw+caqqO4LdPlRkFZAA0n8DIuOB//BriUnnBIf5YasLsMpwkGKzG1ABF1Qpjg==}
     peerDependencies:
       solid-js: ^1.3.1
     dependencies:
-      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/event-listener/2.2.2_solid-js@1.5.4:
+  /@solid-primitives/event-listener/2.2.2_solid-js@1.5.5:
     resolution: {integrity: sha512-0MmaWoY6O6IWDNKiW7ww45FsVN1o2PCjMZv4PTWx+dQD++CaPdCranLv0xc1b5iRKgEFzE52cVa3c82GnsgUEQ==}
     peerDependencies:
       solid-js: ^1.3.1
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/immutable/0.1.2_solid-js@1.5.4:
+  /@solid-primitives/immutable/0.1.2_solid-js@1.5.5:
     resolution: {integrity: sha512-h6P3bhQlgo9qsTfJ7eimUYzKkhf0dFchYPyfvEUy/QcG2eSDkKhhgOz0ss6DSP6cdavTDTaQoquLr/iR8LelMA==}
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
     transitivePeerDependencies:
       - solid-js
     dev: false
 
-  /@solid-primitives/keyboard/1.0.2_solid-js@1.5.4:
+  /@solid-primitives/keyboard/1.0.2_solid-js@1.5.5:
     resolution: {integrity: sha512-7a0FPro6cx4PqsFjWgfK5OpeUGuCbndTTRg0nKEmwdho/8cyepD7HVi5Ep+3tjG5vx+WI+KwYfzK8AM6GB+aUQ==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/keyed/1.1.2_solid-js@1.5.4:
+  /@solid-primitives/keyed/1.1.2_solid-js@1.5.5:
     resolution: {integrity: sha512-FgbscL67X315lTKPM+uK7mjm2nkmzwNs/M+AFhT/yu2NUdTceOD2apW2xeqwE2RRtE/GFy1AI5559NHM3kg0JQ==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/memo/0.3.0_solid-js@1.5.4:
+  /@solid-primitives/memo/0.3.0_solid-js@1.5.5:
     resolution: {integrity: sha512-WQct9lXmDfAmR+5Nu96Cs8KpZJA1DVAepQ4XKfIS/UfeyEDuohOGcq9huwZL23qXrbtbb49seP8cEPcyempsgw==}
     peerDependencies:
       solid-js: ^1.4.2
     dependencies:
-      '@solid-primitives/scheduled': 1.0.0_solid-js@1.5.4
-      '@solid-primitives/utils': 2.1.1_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/scheduled': 1.0.0_solid-js@1.5.5
+      '@solid-primitives/utils': 2.1.1_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/platform/0.0.100_solid-js@1.5.4:
+  /@solid-primitives/platform/0.0.100_solid-js@1.5.5:
     resolution: {integrity: sha512-TMGeDtjA8b7xlUQGq3QhdR8SSa49bvqhFJ0iD+iy4fsnEHr9xA5hIDyBX/ntmz70SbOVyz+z9IdXwBnqurr4bQ==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/props/2.2.2_solid-js@1.5.4:
+  /@solid-primitives/props/2.2.2_solid-js@1.5.5:
     resolution: {integrity: sha512-vjRRoi/z3S2ylIJKCs+mN07oxDmt2S9gPCbTqkEx8jYHnvzocpt34UQdglLoSklTE6jI37JhW3g/Cs8Qr/peHg==}
     peerDependencies:
       solid-js: ^1.3.0
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/refs/0.3.2_solid-js@1.5.4:
+  /@solid-primitives/refs/0.3.2_solid-js@1.5.5:
     resolution: {integrity: sha512-5bwL25wCpnEtlz3cScj3TNHpqeVYAqCbkdmnB/+KLwOJyfNSEm1RsFzOT6SIsd0lRJeY5Of4TeRlUT/tPofAXw==}
     peerDependencies:
       solid-js: ^1.3.0
     dependencies:
-      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/immutable': 0.1.2_solid-js@1.5.5
+      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/resize-observer/2.0.4_solid-js@1.5.4:
+  /@solid-primitives/resize-observer/2.0.4_solid-js@1.5.5:
     resolution: {integrity: sha512-YohOMcQMDLpwSYyJN/fPXErys+o5mTMnpQ9AHFirx8gn0+gYCiF2fBrWtgWdHc8TVy2UUehRFU2Xc5FpiltjtQ==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
-      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.4
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.5
+      '@solid-primitives/rootless': 1.1.3_solid-js@1.5.5
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/rootless/1.1.3_solid-js@1.5.4:
+  /@solid-primitives/rootless/1.1.3_solid-js@1.5.5:
     resolution: {integrity: sha512-cvAILHUrix0xNNmUnxF6MscW2fNEmMk7l/HmAcLcuQyQzd6t1WU6gdL2q9X9ui3LbG3It7qzhHVO3AdDxnkD6g==}
     peerDependencies:
       solid-js: ^1.3.1
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/scheduled/1.0.0_solid-js@1.5.4:
+  /@solid-primitives/scheduled/1.0.0_solid-js@1.5.5:
     resolution: {integrity: sha512-FfzYoAkFCRGBuCuXF8G7fU4J4SK9PhKbwxZvzqk+VVBcowPS1eGlLAtlqW/29paSKlUSxuLuhZxq1sPzwmuvoQ==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/scheduled/1.0.1_solid-js@1.5.4:
+  /@solid-primitives/scheduled/1.0.1_solid-js@1.5.5:
     resolution: {integrity: sha512-zRyW9L4nYdL0yZktvJz/Ye9kVNa6UW26L71sZEqzzHnxvDidbT+mln4np7jqFrAeGiWMwWnRDR/ZvM0FK85jMw==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/set/0.2.2_solid-js@1.5.4:
+  /@solid-primitives/set/0.2.2_solid-js@1.5.5:
     resolution: {integrity: sha512-LQP+zN1WVKoNpoLwLtqbvw6nqaw1v5a7r/OUNnYUgjGR8neHAtJN3XGnk0AM7g0r2Py3Olukvg6qOPAKGnhA+Q==}
     peerDependencies:
       solid-js: ^1.3.0
     dependencies:
-      '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
-      solid-js: 1.5.4
+      '@solid-primitives/utils': 3.0.2_solid-js@1.5.5
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/timer/1.3.2_solid-js@1.5.4:
+  /@solid-primitives/timer/1.3.2_solid-js@1.5.5:
     resolution: {integrity: sha512-l0MICl3Ne4wlN1dAiJqXBDjd8lkt/NjV66HnrPgpEEAaNazvWTkWyH37paHRQRAqpmRpkP2AodJfYmkVQ3dvdA==}
     peerDependencies:
       solid-js: ^1.3.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/utils/2.1.1_solid-js@1.5.4:
+  /@solid-primitives/utils/2.1.1_solid-js@1.5.5:
     resolution: {integrity: sha512-im/WJDgLnJgjuEhB2a46RgDU/ODoc4g+FMySjJ8erPTFrhyTwIe5wv9MSUf7SYsguLe4rfQirNEKLSSyLPETkw==}
     peerDependencies:
       solid-js: ^1.4.1
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solid-primitives/utils/3.0.2_solid-js@1.5.4:
+  /@solid-primitives/utils/3.0.2_solid-js@1.5.5:
     resolution: {integrity: sha512-LCU3tVrJmyRqJ0ocG5uCEuUNqmGkcAC+cWpDEE49AuvtehkdQfv4CfqvdNJgs3eoQRQhLOrVcgd1bHFJY4lsrQ==}
     peerDependencies:
       solid-js: ^1.4.1
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /@solidjs/meta/0.28.0_solid-js@1.5.1:
+  /@solidjs/meta/0.28.0_solid-js@1.5.5:
     resolution: {integrity: sha512-x52VdB9RZJ1apDB/pAmf58oeJsJ0lGKFXWjnm/TE/MlENIBPg3JaW8H5v2HnGpQC0WUbgiIsDFWpLWVNBo5t6g==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
-      solid-js: 1.5.1
+      solid-js: 1.5.5
 
-  /@solidjs/router/0.4.3_solid-js@1.5.1:
+  /@solidjs/router/0.4.3_solid-js@1.5.5:
     resolution: {integrity: sha512-mYpd4HxpH/3UZjHGTr2dhvPGXu034Ktxd05CJGA6nRjRGYCgUfhCQHRdEivyqJyb4LhHyDht4ny5xmwEOkUTaQ==}
     peerDependencies:
       solid-js: ^1.3.5
     dependencies:
-      solid-js: 1.5.1
+      solid-js: 1.5.5
 
   /@testing-library/jest-dom/5.16.5:
     resolution: {integrity: sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==}
@@ -4492,8 +4492,8 @@ packages:
     resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
     dev: true
 
-  /@types/node/18.7.15:
-    resolution: {integrity: sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==}
+  /@types/node/18.7.18:
+    resolution: {integrity: sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==}
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -5567,6 +5567,9 @@ packages:
   /csstype/3.1.0:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
 
+  /csstype/3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+
   /csv-generate/3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
     dev: true
@@ -6452,7 +6455,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid/0.4.2_bwcvipldrmzlcczfdyw74a3qbi:
+  /esbuild-plugin-solid/0.4.2_6ptba4h3py425bf34khwc276eu:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -6462,12 +6465,12 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
       babel-preset-solid: 1.4.8_@babel+core@7.18.10
       esbuild: 0.15.7
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /esbuild-plugin-solid/0.4.2_kdtxu7zkztxu5bgafyqjgjsfvy:
+  /esbuild-plugin-solid/0.4.2_dnb7jb4m7l53iwnykiyaipi6jq:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -6477,7 +6480,7 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
       babel-preset-solid: 1.4.8_@babel+core@7.18.10
       esbuild: 0.14.54
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7633,34 +7636,6 @@ packages:
       - ts-node
     dev: true
 
-  /jest-cli/28.1.3_5vwfwon4dwup6lzh6jzd72qfva:
-    resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 28.1.3_ts-node@10.9.1
-      '@jest/test-result': 28.1.3
-      '@jest/types': 28.1.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      jest-config: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      prompts: 2.4.2
-      yargs: 17.5.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: true
-
   /jest-cli/28.1.3_@types+node@17.0.45:
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -7679,6 +7654,34 @@ packages:
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 28.1.3_@types+node@17.0.45
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      prompts: 2.4.2
+      yargs: 17.5.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest-cli/28.1.3_sgupjgtkb76w4hsvieap2xky7i:
+    resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 28.1.3_ts-node@10.9.1
+      '@jest/test-result': 28.1.3
+      '@jest/types': 28.1.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      import-local: 3.1.0
+      jest-config: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -7723,46 +7726,6 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /jest-config/28.1.3_5vwfwon4dwup6lzh6jzd72qfva:
-    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.10
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.7.15
-      babel-jest: 28.1.3_@babel+core@7.18.10
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7880,7 +7843,47 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-config/28.1.3_sgupjgtkb76w4hsvieap2xky7i:
+    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@jest/test-sequencer': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 18.7.18
+      babel-jest: 28.1.3_@babel+core@7.18.10
+      chalk: 4.1.2
+      ci-info: 3.3.2
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8217,26 +8220,6 @@ packages:
       - ts-node
     dev: true
 
-  /jest/28.1.3_5vwfwon4dwup6lzh6jzd72qfva:
-    resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 28.1.3_ts-node@10.9.1
-      '@jest/types': 28.1.3
-      import-local: 3.1.0
-      jest-cli: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: true
-
   /jest/28.1.3_@types+node@17.0.45:
     resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -8251,6 +8234,26 @@ packages:
       '@jest/types': 28.1.3
       import-local: 3.1.0
       jest-cli: 28.1.3_@types+node@17.0.45
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest/28.1.3_sgupjgtkb76w4hsvieap2xky7i:
+    resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 28.1.3_ts-node@10.9.1
+      '@jest/types': 28.1.3
+      import-local: 3.1.0
+      jest-cli: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -9244,7 +9247,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.5
-      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
+      ts-node: 10.9.1_sqdlidqb5kymhugfdzbb24uaie
       yaml: 1.10.2
     dev: true
 
@@ -9801,31 +9804,26 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
-  /solid-js/1.5.1:
-    resolution: {integrity: sha512-Y6aKystIxnrB0quV5nhqNuJV+l2Fk3/PQy1mMya/bzxlGiMHAym7v1NaqEgqDIvctbkxOi5dBj0ER/ewrH060g==}
-    dependencies:
-      csstype: 3.1.0
-
   /solid-js/1.5.2:
     resolution: {integrity: sha512-4dUeAVVJsMNLuEZ4VjGYf3rUgOc2CXEvzp/Q01UcF1EJBnMoqhYmXTEDiLD829kAyDpgnE1O0bXG1PzYYiXOZQ==}
     dependencies:
       csstype: 3.1.0
     dev: false
 
-  /solid-js/1.5.4:
-    resolution: {integrity: sha512-+65anSHhH27htkhP5LuC912fviMIckgc7/yN+WWrKhS9Kp3dvtDNl5/m4GWX1lpCvcubjShqJjGt16HET5z5Ig==}
+  /solid-js/1.5.5:
+    resolution: {integrity: sha512-5gXszD7ekhe59IyMa3+AvREJnBWVjwaeC7afL8C3UNPj5gQQCrsMs/cXwI3JRpj6D+3TESTyuQ2sY++m4cYiTg==}
     dependencies:
-      csstype: 3.1.0
+      csstype: 3.1.1
 
-  /solid-meta/0.27.5_solid-js@1.5.4:
+  /solid-meta/0.27.5_solid-js@1.5.5:
     resolution: {integrity: sha512-9OA50aNBhCwuFo1Uby9NT3gB6I6iBRN0mSXkXROJyWDtmyhdw9iyMT9JsnGF/A/7IQq2BSLV75oPQjNKQAMeQw==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /solid-refresh/0.4.1_solid-js@1.5.1:
+  /solid-refresh/0.4.1_solid-js@1.5.5:
     resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
     peerDependencies:
       solid-js: ^1.3
@@ -9833,18 +9831,7 @@ packages:
       '@babel/generator': 7.18.10
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.18.10
-      solid-js: 1.5.1
-
-  /solid-refresh/0.4.1_solid-js@1.5.4:
-    resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
-    peerDependencies:
-      solid-js: ^1.3
-    dependencies:
-      '@babel/generator': 7.18.10
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/types': 7.18.10
-      solid-js: 1.5.4
-    dev: true
+      solid-js: 1.5.5
 
   /solid-start-node/0.1.0-alpha.99_ezo5wys7wfnonswu4qg56iwwqy:
     resolution: {integrity: sha512-uFADbfLY4Bbdf7iT7IMUAqj6GoM85Y3CN11UGkdVvB/O9vHXfRjfvwsyb1Yg5UMbJaQU30ACl4Wduj22HjcCzQ==}
@@ -9860,7 +9847,7 @@ packages:
       polka: 1.0.0-next.22
       rollup: 2.78.1
       sirv: 2.0.2
-      solid-start: 0.1.0-alpha.99_zbd6upuqjs243od46l5stqtfw4
+      solid-start: 0.1.0-alpha.99_2fe554iznd4cemlxxayhcxqy3q
       terser: 5.14.2
       undici: 5.10.0
       vite: 3.0.9
@@ -9868,7 +9855,7 @@ packages:
       - supports-color
     dev: true
 
-  /solid-start/0.1.0-alpha.99_zbd6upuqjs243od46l5stqtfw4:
+  /solid-start/0.1.0-alpha.99_2fe554iznd4cemlxxayhcxqy3q:
     resolution: {integrity: sha512-ODzODpXQ3fV6txTYa92C5qCKbd0M/CzzZPknaP6+IrzwNL1aRobepkhKz0rMT3BJLQAVHoSq/dHytsT/ZYw6Jw==}
     hasBin: true
     peerDependencies:
@@ -9883,8 +9870,8 @@ packages:
       '@babel/preset-env': 7.18.10_@babel+core@7.18.13
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.13
       '@babel/template': 7.18.10
-      '@solidjs/meta': 0.28.0_solid-js@1.5.1
-      '@solidjs/router': 0.4.3_solid-js@1.5.1
+      '@solidjs/meta': 0.28.0_solid-js@1.5.5
+      '@solidjs/router': 0.4.3_solid-js@1.5.5
       '@types/cookie': 0.5.1
       chokidar: 3.5.3
       compression: 1.7.4
@@ -9901,30 +9888,30 @@ packages:
       rollup-route-manifest: 1.0.0_rollup@2.78.1
       sade: 1.8.1
       sirv: 2.0.2
-      solid-js: 1.5.1
+      solid-js: 1.5.5
       terser: 5.14.2
       undici: 5.10.0
       vite: 3.0.9
       vite-plugin-inspect: 0.6.0_vite@3.0.9
-      vite-plugin-solid: 2.3.0_solid-js@1.5.1+vite@3.0.9
+      vite-plugin-solid: 2.3.0_solid-js@1.5.5+vite@3.0.9
       wait-on: 6.0.1_debug@4.3.4
     transitivePeerDependencies:
       - supports-color
 
-  /solid-transition-group/0.0.10_solid-js@1.5.4:
+  /solid-transition-group/0.0.10_solid-js@1.5.5:
     resolution: {integrity: sha512-b3O9z6BUP60CG1WnTdqFuvHms0reDNYwQF+eAEEaSaoDEmiOu9+Lu7zQgWGySJjaAdSAClhmFCmx/eAjQgfIoA==}
     peerDependencies:
       solid-js: ^1.0.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
-  /solid-transition-group/0.0.11_solid-js@1.5.4:
+  /solid-transition-group/0.0.11_solid-js@1.5.5:
     resolution: {integrity: sha512-WcMhZvaQKAWfByVgtJuKwR2naXQHG1tJHDvqsC/EyNsoNWRkDu+9AWcwaUWW1kXZ24n17We0IIRe7z4G5dEYRw==}
     peerDependencies:
       solid-js: ^1.0.0
     dependencies:
-      solid-js: 1.5.4
+      solid-js: 1.5.5
     dev: false
 
   /source-map-js/1.0.2:
@@ -10360,7 +10347,7 @@ packages:
       yargs-parser: 21.0.1
     dev: true
 
-  /ts-node/10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe:
+  /ts-node/10.9.1_sqdlidqb5kymhugfdzbb24uaie:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10379,7 +10366,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.7.15
+      '@types/node': 18.7.18
       acorn: 8.7.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -10798,7 +10785,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /vite-plugin-solid/2.3.0_solid-js@1.5.1+vite@3.0.9:
+  /vite-plugin-solid/2.3.0_solid-js@1.5.5+vite@3.0.9:
     resolution: {integrity: sha512-N2sa54C3UZC2nN5vpj5o6YP+XdIAZW6n6xv8OasxNAcAJPFeZT7EOVvumL0V4c8hBz1yuYniMWdESY8807fVSg==}
     peerDependencies:
       solid-js: ^1.3.17
@@ -10808,28 +10795,11 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
       babel-preset-solid: 1.4.8_@babel+core@7.18.10
       merge-anything: 5.0.2
-      solid-js: 1.5.1
-      solid-refresh: 0.4.1_solid-js@1.5.1
+      solid-js: 1.5.5
+      solid-refresh: 0.4.1_solid-js@1.5.5
       vite: 3.0.9
     transitivePeerDependencies:
       - supports-color
-
-  /vite-plugin-solid/2.3.0_solid-js@1.5.4+vite@3.0.9:
-    resolution: {integrity: sha512-N2sa54C3UZC2nN5vpj5o6YP+XdIAZW6n6xv8OasxNAcAJPFeZT7EOVvumL0V4c8hBz1yuYniMWdESY8807fVSg==}
-    peerDependencies:
-      solid-js: ^1.3.17
-      vite: ^3.0.0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
-      babel-preset-solid: 1.4.8_@babel+core@7.18.10
-      merge-anything: 5.0.2
-      solid-js: 1.5.4
-      solid-refresh: 0.4.1_solid-js@1.5.4
-      vite: 3.0.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /vite/3.0.9:
     resolution: {integrity: sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,10 +73,10 @@ importers:
       '@solid-devtools/transform': link:../transform
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
+      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -110,7 +110,7 @@ importers:
       '@solid-primitives/context': ^0.1.1
       '@solid-primitives/destructure': ^0.1.2
       '@solid-primitives/immutable': ^0.1.2
-      '@solid-primitives/keyed': ^1.1.1
+      '@solid-primitives/keyed': ^1.1.2
       '@solid-primitives/props': ^2.2.2
       '@solid-primitives/rootless': ^1.1.3
       '@solid-primitives/set': ^0.2.2
@@ -134,7 +134,7 @@ importers:
       '@solid-primitives/context': 0.1.1_solid-js@1.5.4
       '@solid-primitives/destructure': 0.1.2_solid-js@1.5.4
       '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/keyed': 1.1.1_solid-js@1.5.4
+      '@solid-primitives/keyed': 1.1.2_solid-js@1.5.4
       '@solid-primitives/props': 2.2.2_solid-js@1.5.4
       '@solid-primitives/rootless': 1.1.3_solid-js@1.5.4
       '@solid-primitives/set': 0.2.2_solid-js@1.5.4
@@ -197,10 +197,10 @@ importers:
       '@testing-library/jest-dom': 5.16.5
       esbuild: 0.14.54
       esbuild-plugin-solid: 0.4.2_kdtxu7zkztxu5bgafyqjgjsfvy
-      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
+      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -222,10 +222,10 @@ importers:
       '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
+      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -249,10 +249,10 @@ importers:
       '@solid-devtools/transform': link:../transform
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
+      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -299,11 +299,11 @@ importers:
       '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
       '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
       solid-js: 1.5.4
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
       type-fest: 2.19.0
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
+      jest: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
       jest-environment-jsdom: 28.1.3
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
@@ -356,7 +356,7 @@ importers:
       '@solid-primitives/cursor': ^0.0.100
       '@solid-primitives/event-listener': ^2.2.2
       '@solid-primitives/keyboard': ^1.0.2
-      '@solid-primitives/keyed': ^1.1.1
+      '@solid-primitives/keyed': ^1.1.2
       '@solid-primitives/props': ^2.2.2
       '@solid-primitives/resize-observer': ^2.0.4
       '@solid-primitives/timer': ^1.3.2
@@ -382,7 +382,7 @@ importers:
       '@solid-primitives/cursor': 0.0.100_solid-js@1.5.4
       '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
       '@solid-primitives/keyboard': 1.0.2_solid-js@1.5.4
-      '@solid-primitives/keyed': 1.1.1_solid-js@1.5.4
+      '@solid-primitives/keyed': 1.1.2_solid-js@1.5.4
       '@solid-primitives/props': 2.2.2_solid-js@1.5.4
       '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.4
       '@solid-primitives/timer': 1.3.2_solid-js@1.5.4
@@ -3355,7 +3355,7 @@ packages:
       rollup: 2.78.1
       vite: 3.0.9
     optionalDependencies:
-      '@vitejs/plugin-react': 2.0.1_vite@3.0.9
+      '@vitejs/plugin-react': 2.1.0_vite@3.0.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4211,8 +4211,8 @@ packages:
       solid-js: 1.5.4
     dev: false
 
-  /@solid-primitives/keyed/1.1.1_solid-js@1.5.4:
-    resolution: {integrity: sha512-inFYqrDA1tsPKzkyBXEaduEnVa21XfHmOmeA75a2On7cuH5ssKPIbPOMzIdv4w87KWEzMGMxkFfAF2CQfuOlPA==}
+  /@solid-primitives/keyed/1.1.2_solid-js@1.5.4:
+    resolution: {integrity: sha512-FgbscL67X315lTKPM+uK7mjm2nkmzwNs/M+AFhT/yu2NUdTceOD2apW2xeqwE2RRtE/GFy1AI5559NHM3kg0JQ==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
@@ -4492,8 +4492,8 @@ packages:
     resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
     dev: true
 
-  /@types/node/18.7.14:
-    resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
+  /@types/node/18.7.15:
+    resolution: {integrity: sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==}
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -4597,8 +4597,8 @@ packages:
       - ts-node
     dev: true
 
-  /@vitejs/plugin-react/2.0.1_vite@3.0.9:
-    resolution: {integrity: sha512-uINzNHmjrbunlFtyVkST6lY1ewSfz/XwLufG0PIqvLGnpk2nOIOa/1CACTDNcKi1/RwaCzJLmsXwm1NsUVV/NA==}
+  /@vitejs/plugin-react/2.1.0_vite@3.0.9:
+    resolution: {integrity: sha512-am6rPyyU3LzUYne3Gd9oj9c4Rzbq5hQnuGXSMT6Gujq45Il/+bunwq3lrB7wghLkiF45ygMwft37vgJ/NE8IAA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     requiresBuild: true
     peerDependencies:
@@ -7633,6 +7633,34 @@ packages:
       - ts-node
     dev: true
 
+  /jest-cli/28.1.3_5vwfwon4dwup6lzh6jzd72qfva:
+    resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 28.1.3_ts-node@10.9.1
+      '@jest/test-result': 28.1.3
+      '@jest/types': 28.1.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      import-local: 3.1.0
+      jest-config: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      prompts: 2.4.2
+      yargs: 17.5.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest-cli/28.1.3_@types+node@17.0.45:
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -7651,34 +7679,6 @@ packages:
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 28.1.3_@types+node@17.0.45
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      prompts: 2.4.2
-      yargs: 17.5.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest-cli/28.1.3_gsb7asu77en4txj3es3i65pxci:
-    resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 28.1.3_ts-node@10.9.1
-      '@jest/test-result': 28.1.3
-      '@jest/types': 28.1.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10
-      import-local: 3.1.0
-      jest-config: 28.1.3_gsb7asu77en4txj3es3i65pxci
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -7723,6 +7723,46 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-config/28.1.3_5vwfwon4dwup6lzh6jzd72qfva:
+    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@jest/test-sequencer': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 18.7.15
+      babel-jest: 28.1.3_@babel+core@7.18.10
+      chalk: 4.1.2
+      ci-info: 3.3.2
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7840,47 +7880,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /jest-config/28.1.3_gsb7asu77en4txj3es3i65pxci:
-    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.10
-      '@jest/test-sequencer': 28.1.3
-      '@jest/types': 28.1.3
-      '@types/node': 18.7.14
-      babel-jest: 28.1.3_@babel+core@7.18.10
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 28.1.3
-      jest-environment-node: 28.1.3
-      jest-get-type: 28.0.2
-      jest-regex-util: 28.0.2
-      jest-resolve: 28.1.3
-      jest-runner: 28.1.3
-      jest-util: 28.1.3
-      jest-validate: 28.1.3
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 28.1.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8217,6 +8217,26 @@ packages:
       - ts-node
     dev: true
 
+  /jest/28.1.3_5vwfwon4dwup6lzh6jzd72qfva:
+    resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 28.1.3_ts-node@10.9.1
+      '@jest/types': 28.1.3
+      import-local: 3.1.0
+      jest-cli: 28.1.3_5vwfwon4dwup6lzh6jzd72qfva
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest/28.1.3_@types+node@17.0.45:
     resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -8231,26 +8251,6 @@ packages:
       '@jest/types': 28.1.3
       import-local: 3.1.0
       jest-cli: 28.1.3_@types+node@17.0.45
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest/28.1.3_gsb7asu77en4txj3es3i65pxci:
-    resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 28.1.3_ts-node@10.9.1
-      '@jest/types': 28.1.3
-      import-local: 3.1.0
-      jest-cli: 28.1.3_gsb7asu77en4txj3es3i65pxci
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -9244,7 +9244,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.5
-      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+      ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
       yaml: 1.10.2
     dev: true
 
@@ -10360,7 +10360,7 @@ packages:
       yargs-parser: 21.0.1
     dev: true
 
-  /ts-node/10.9.1_tphhiizkxv2hzwkunblc3hbmra:
+  /ts-node/10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10379,7 +10379,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.7.14
+      '@types/node': 18.7.15
       acorn: 8.7.1
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,7 @@ importers:
       '@solid-primitives/context': ^0.1.1
       '@solid-primitives/destructure': ^0.1.2
       '@solid-primitives/immutable': ^0.1.2
+      '@solid-primitives/keyed': ^1.0.2
       '@solid-primitives/props': ^2.2.2
       '@solid-primitives/rootless': ^1.1.3
       '@solid-primitives/set': ^0.2.2
@@ -133,6 +134,7 @@ importers:
       '@solid-primitives/context': 0.1.1_solid-js@1.5.4
       '@solid-primitives/destructure': 0.1.2_solid-js@1.5.4
       '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
+      '@solid-primitives/keyed': 1.0.2_solid-js@1.5.4
       '@solid-primitives/props': 2.2.2_solid-js@1.5.4
       '@solid-primitives/rootless': 1.1.3_solid-js@1.5.4
       '@solid-primitives/set': 0.2.2_solid-js@1.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,10 +73,10 @@ importers:
       '@solid-devtools/transform': link:../transform
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_g3ob4elhesv7uyo2jbxkqs7hje
+      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_77qufrcolqt5x2bjepbsxfbcpy
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -110,7 +110,7 @@ importers:
       '@solid-primitives/context': ^0.1.1
       '@solid-primitives/destructure': ^0.1.2
       '@solid-primitives/immutable': ^0.1.2
-      '@solid-primitives/keyed': ^1.0.2
+      '@solid-primitives/keyed': ^1.1.1
       '@solid-primitives/props': ^2.2.2
       '@solid-primitives/rootless': ^1.1.3
       '@solid-primitives/set': ^0.2.2
@@ -134,7 +134,7 @@ importers:
       '@solid-primitives/context': 0.1.1_solid-js@1.5.4
       '@solid-primitives/destructure': 0.1.2_solid-js@1.5.4
       '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
-      '@solid-primitives/keyed': 1.0.2_solid-js@1.5.4
+      '@solid-primitives/keyed': 1.1.1_solid-js@1.5.4
       '@solid-primitives/props': 2.2.2_solid-js@1.5.4
       '@solid-primitives/rootless': 1.1.3_solid-js@1.5.4
       '@solid-primitives/set': 0.2.2_solid-js@1.5.4
@@ -149,7 +149,7 @@ importers:
       '@solid-devtools/ext-adapter': link:../ext-adapter
       '@types/chrome': 0.0.193
       '@vanilla-extract/vite-plugin': 3.3.1_vite@3.0.9
-      esbuild-plugin-solid: 0.4.2_xybkfzdsahgdimry3w5c4gfvbu
+      esbuild-plugin-solid: 0.4.2_bwcvipldrmzlcczfdyw74a3qbi
       rimraf: 3.0.2
       typescript: 4.8.2
       vite: 3.0.9
@@ -197,10 +197,10 @@ importers:
       '@testing-library/jest-dom': 5.16.5
       esbuild: 0.14.54
       esbuild-plugin-solid: 0.4.2_kdtxu7zkztxu5bgafyqjgjsfvy
-      jest: 28.1.3_g3ob4elhesv7uyo2jbxkqs7hje
+      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_77qufrcolqt5x2bjepbsxfbcpy
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -222,10 +222,10 @@ importers:
       '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_g3ob4elhesv7uyo2jbxkqs7hje
+      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_77qufrcolqt5x2bjepbsxfbcpy
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -249,10 +249,10 @@ importers:
       '@solid-devtools/transform': link:../transform
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_g3ob4elhesv7uyo2jbxkqs7hje
+      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
       jest-environment-jsdom: 28.1.3
       solid-js: 1.5.4
-      ts-node: 10.9.1_77qufrcolqt5x2bjepbsxfbcpy
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
 
@@ -299,11 +299,11 @@ importers:
       '@solid-primitives/immutable': 0.1.2_solid-js@1.5.4
       '@solid-primitives/utils': 3.0.2_solid-js@1.5.4
       solid-js: 1.5.4
-      ts-node: 10.9.1_77qufrcolqt5x2bjepbsxfbcpy
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
       type-fest: 2.19.0
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      jest: 28.1.3_g3ob4elhesv7uyo2jbxkqs7hje
+      jest: 28.1.3_gsb7asu77en4txj3es3i65pxci
       jest-environment-jsdom: 28.1.3
       tsup: 6.2.3_s5ojjbx2isjkawqptqpitvy25q
       typescript: 4.8.2
@@ -356,7 +356,7 @@ importers:
       '@solid-primitives/cursor': ^0.0.100
       '@solid-primitives/event-listener': ^2.2.2
       '@solid-primitives/keyboard': ^1.0.2
-      '@solid-primitives/keyed': ^1.0.2
+      '@solid-primitives/keyed': ^1.1.1
       '@solid-primitives/props': ^2.2.2
       '@solid-primitives/resize-observer': ^2.0.4
       '@solid-primitives/timer': ^1.3.2
@@ -382,7 +382,7 @@ importers:
       '@solid-primitives/cursor': 0.0.100_solid-js@1.5.4
       '@solid-primitives/event-listener': 2.2.2_solid-js@1.5.4
       '@solid-primitives/keyboard': 1.0.2_solid-js@1.5.4
-      '@solid-primitives/keyed': 1.0.2_solid-js@1.5.4
+      '@solid-primitives/keyed': 1.1.1_solid-js@1.5.4
       '@solid-primitives/props': 2.2.2_solid-js@1.5.4
       '@solid-primitives/resize-observer': 2.0.4_solid-js@1.5.4
       '@solid-primitives/timer': 1.3.2_solid-js@1.5.4
@@ -616,13 +616,6 @@ packages:
       jsesc: 2.5.2
     dev: true
 
-  /@babel/helper-annotate-as-pure/7.16.7:
-    resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.4
-    dev: true
-
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
@@ -642,7 +635,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
 
   /@babel/helper-compilation-targets/7.18.2_@babel+core@7.18.2:
     resolution: {integrity: sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==}
@@ -688,7 +681,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.2
       '@babel/helper-function-name': 7.17.9
       '@babel/helper-member-expression-to-functions': 7.17.7
@@ -758,7 +751,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.0.1
     dev: true
 
@@ -836,7 +829,7 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
 
   /@babel/helper-function-name/7.17.9:
     resolution: {integrity: sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==}
@@ -877,7 +870,7 @@ packages:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
 
   /@babel/helper-module-imports/7.16.0:
     resolution: {integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==}
@@ -889,21 +882,21 @@ packages:
     resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.4
+      '@babel/types': 7.18.13
     dev: true
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.10
+      '@babel/types': 7.18.13
 
   /@babel/helper-module-transforms/7.18.0:
     resolution: {integrity: sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.2
-      '@babel/helper-module-imports': 7.16.7
+      '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.18.2
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/helper-validator-identifier': 7.16.7
@@ -940,7 +933,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
 
   /@babel/helper-plugin-utils/7.17.12:
     resolution: {integrity: sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==}
@@ -960,7 +953,7 @@ packages:
     resolution: {integrity: sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-wrap-function': 7.16.8
       '@babel/types': 7.18.4
     transitivePeerDependencies:
@@ -977,7 +970,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.18.10
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
     transitivePeerDependencies:
       - supports-color
 
@@ -1002,7 +995,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/traverse': 7.18.13
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
     transitivePeerDependencies:
       - supports-color
 
@@ -1017,7 +1010,7 @@ packages:
     resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.10
+      '@babel/types': 7.18.13
 
   /@babel/helper-skip-transparent-expression-wrappers/7.16.0:
     resolution: {integrity: sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==}
@@ -1030,7 +1023,7 @@ packages:
     resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
 
   /@babel/helper-split-export-declaration/7.16.7:
     resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
@@ -1086,7 +1079,7 @@ packages:
       '@babel/helper-function-name': 7.18.9
       '@babel/template': 7.18.10
       '@babel/traverse': 7.18.10
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
     transitivePeerDependencies:
       - supports-color
 
@@ -1509,7 +1502,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-create-class-features-plugin': 7.18.0_@babel+core@7.18.2
       '@babel/helper-plugin-utils': 7.17.12
       '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.18.2
@@ -1749,16 +1742,6 @@ packages:
       '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
-  /@babel/plugin-syntax-jsx/7.17.12_@babel+core@7.18.2:
-    resolution: {integrity: sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.2
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.10:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
@@ -1776,6 +1759,16 @@ packages:
     dependencies:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.18.9
+
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.2:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.2
+      '@babel/helper-plugin-utils': 7.18.9
+    dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.10:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -2035,7 +2028,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-module-imports': 7.16.7
+      '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.17.12
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
@@ -2100,7 +2093,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.2
-      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.2
       '@babel/helper-function-name': 7.17.9
       '@babel/helper-optimise-call-expression': 7.16.7
@@ -2535,30 +2528,19 @@ packages:
       '@babel/core': 7.18.13
       '@babel/helper-plugin-utils': 7.18.9
 
-  /@babel/plugin-transform-react-jsx-development/7.16.7_@babel+core@7.18.13:
-    resolution: {integrity: sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==}
+  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.18.13:
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.18.13
-      '@babel/plugin-transform-react-jsx': 7.17.12_@babel+core@7.18.13
+      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.18.13
     dev: true
     optional: true
 
-  /@babel/plugin-transform-react-jsx-self/7.17.12_@babel+core@7.18.13:
-    resolution: {integrity: sha512-7S9G2B44EnYOx74mue02t1uD8ckWZ/ee6Uz/qfdzc35uWHX5NgRy9i+iJSb2LFRgMd+QV9zNcStQaazzzZ3n3Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.13
-      '@babel/helper-plugin-utils': 7.18.9
-    dev: true
-    optional: true
-
-  /@babel/plugin-transform-react-jsx-source/7.16.7_@babel+core@7.18.13:
-    resolution: {integrity: sha512-rONFiQz9vgbsnaMtQlZCjIRwhJvlrPET8TabIUK2hzlXw9B9s2Ieaxte1SCOOXMbWRHodbKixNf3BLcWVOQ8Bw==}
+  /@babel/plugin-transform-react-jsx-self/7.18.6_@babel+core@7.18.13:
+    resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2568,8 +2550,19 @@ packages:
     dev: true
     optional: true
 
-  /@babel/plugin-transform-react-jsx/7.17.12_@babel+core@7.18.13:
-    resolution: {integrity: sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==}
+  /@babel/plugin-transform-react-jsx-source/7.18.6_@babel+core@7.18.13:
+    resolution: {integrity: sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.18.13
+      '@babel/helper-plugin-utils': 7.18.9
+    dev: true
+    optional: true
+
+  /@babel/plugin-transform-react-jsx/7.18.10_@babel+core@7.18.13:
+    resolution: {integrity: sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2980,7 +2973,7 @@ packages:
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.18.13
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.18.13
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
       esutils: 2.0.3
 
   /@babel/preset-modules/0.1.5_@babel+core@7.18.2:
@@ -2992,7 +2985,7 @@ packages:
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.18.2
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.18.2
-      '@babel/types': 7.18.13
+      '@babel/types': 7.18.10
       esutils: 2.0.3
     dev: true
 
@@ -3362,7 +3355,7 @@ packages:
       rollup: 2.78.1
       vite: 3.0.9
     optionalDependencies:
-      '@vitejs/plugin-react': 1.3.2
+      '@vitejs/plugin-react': 2.0.1_vite@3.0.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3386,6 +3379,15 @@ packages:
 
   /@esbuild/linux-loong64/0.15.6:
     resolution: {integrity: sha512-hqmVU2mUjH6J2ZivHphJ/Pdse2ZD+uGCHK0uvsiLDk/JnSedEVj77CiVUnbMKuU4tih1TZZL8tG9DExQg/GZsw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.15.7:
+    resolution: {integrity: sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -4209,8 +4211,8 @@ packages:
       solid-js: 1.5.4
     dev: false
 
-  /@solid-primitives/keyed/1.0.2_solid-js@1.5.4:
-    resolution: {integrity: sha512-UNgCksI/5D52NnkGNCHYoGbAv6ECGLTIKcrHqYWI2kZnfBK1FxMGTWfaKp1sbZOPBEx8K2gFHM9haeYxmLrFnw==}
+  /@solid-primitives/keyed/1.1.1_solid-js@1.5.4:
+    resolution: {integrity: sha512-inFYqrDA1tsPKzkyBXEaduEnVa21XfHmOmeA75a2On7cuH5ssKPIbPOMzIdv4w87KWEzMGMxkFfAF2CQfuOlPA==}
     peerDependencies:
       solid-js: ^1.4.0
     dependencies:
@@ -4488,6 +4490,10 @@ packages:
 
   /@types/node/18.0.0:
     resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
+    dev: true
+
+  /@types/node/18.7.14:
+    resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -4591,19 +4597,21 @@ packages:
       - ts-node
     dev: true
 
-  /@vitejs/plugin-react/1.3.2:
-    resolution: {integrity: sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==}
-    engines: {node: '>=12.0.0'}
+  /@vitejs/plugin-react/2.0.1_vite@3.0.9:
+    resolution: {integrity: sha512-uINzNHmjrbunlFtyVkST6lY1ewSfz/XwLufG0PIqvLGnpk2nOIOa/1CACTDNcKi1/RwaCzJLmsXwm1NsUVV/NA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     requiresBuild: true
+    peerDependencies:
+      vite: ^3.0.0
     dependencies:
       '@babel/core': 7.18.13
-      '@babel/plugin-transform-react-jsx': 7.17.12_@babel+core@7.18.13
-      '@babel/plugin-transform-react-jsx-development': 7.16.7_@babel+core@7.18.13
-      '@babel/plugin-transform-react-jsx-self': 7.17.12_@babel+core@7.18.13
-      '@babel/plugin-transform-react-jsx-source': 7.16.7_@babel+core@7.18.13
-      '@rollup/pluginutils': 4.2.1
-      react-refresh: 0.13.0
-      resolve: 1.22.1
+      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.18.13
+      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.18.13
+      '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.18.13
+      '@babel/plugin-transform-react-jsx-source': 7.18.6_@babel+core@7.18.13
+      magic-string: 0.26.2
+      react-refresh: 0.14.0
+      vite: 3.0.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4872,15 +4880,15 @@ packages:
       '@babel/core': 7.18.10
       '@babel/helper-module-imports': 7.16.0
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
-      '@babel/types': 7.18.10
+      '@babel/types': 7.18.13
       html-entities: 2.3.2
 
   /babel-plugin-jsx-dom-expressions/0.33.7_@babel+core@7.18.2:
     resolution: {integrity: sha512-2RsP7+i8KAd7EPxw3L1mJ9YGhxF56YJ0qQgWgPRiWWECzmxd3RYc+gaIwPw0yZRTN5Z0xQfa+3yTdNgDzq36dQ==}
     dependencies:
       '@babel/helper-module-imports': 7.16.0
-      '@babel/plugin-syntax-jsx': 7.17.12_@babel+core@7.18.2
-      '@babel/types': 7.18.4
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.2
+      '@babel/types': 7.18.13
       html-entities: 2.3.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -5910,6 +5918,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-android-64/0.15.7:
+    resolution: {integrity: sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-android-arm64/0.14.39:
     resolution: {integrity: sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==}
     engines: {node: '>=12'}
@@ -5929,6 +5946,15 @@ packages:
 
   /esbuild-android-arm64/0.15.6:
     resolution: {integrity: sha512-mvM+gqNxqKm2pCa3dnjdRzl7gIowuc4ga7P7c3yHzs58Im8v/Lfk1ixSgQ2USgIywT48QWaACRa3F4MG7djpSw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.15.7:
+    resolution: {integrity: sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -5962,6 +5988,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-64/0.15.7:
+    resolution: {integrity: sha512-KGPt3r1c9ww009t2xLB6Vk0YyNOXh7hbjZ3EecHoVDxgtbUlYstMPDaReimKe6eOEfyY4hBEEeTvKwPsiH5WZg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-arm64/0.14.39:
     resolution: {integrity: sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==}
     engines: {node: '>=12'}
@@ -5981,6 +6016,15 @@ packages:
 
   /esbuild-darwin-arm64/0.15.6:
     resolution: {integrity: sha512-CnrAeJaEpPakUobhqO4wVSA4Zm6TPaI5UY4EsI62j9mTrjIyQPXA1n4Ju6Iu5TVZRnEqV6q8blodgYJ6CJuwCA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.15.7:
+    resolution: {integrity: sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -6014,6 +6058,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-64/0.15.7:
+    resolution: {integrity: sha512-hESZB91qDLV5MEwNxzMxPfbjAhOmtfsr9Wnuci7pY6TtEh4UDuevmGmkUIjX/b+e/k4tcNBMf7SRQ2mdNuK/HQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-arm64/0.14.39:
     resolution: {integrity: sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==}
     engines: {node: '>=12'}
@@ -6033,6 +6086,15 @@ packages:
 
   /esbuild-freebsd-arm64/0.15.6:
     resolution: {integrity: sha512-KtQkQOhnNciXm2yrTYZMD3MOm2zBiiwFSU+dkwNbcfDumzzUprr1x70ClTdGuZwieBS1BM/k0KajRQX7r504Xw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.15.7:
+    resolution: {integrity: sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -6066,6 +6128,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-32/0.15.7:
+    resolution: {integrity: sha512-v3gT/LsONGUZcjbt2swrMjwxo32NJzk+7sAgtxhGx1+ZmOFaTRXBAi1PPfgpeo/J//Un2jIKm/I+qqeo4caJvg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-64/0.14.39:
     resolution: {integrity: sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==}
     engines: {node: '>=12'}
@@ -6085,6 +6156,15 @@ packages:
 
   /esbuild-linux-64/0.15.6:
     resolution: {integrity: sha512-gQPksyrEYfA4LJwyfTQWAZaVZCx4wpaLrSzo2+Xc9QLC+i/sMWmX31jBjrn4nLJCd79KvwCinto36QC7BEIU/A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.15.7:
+    resolution: {integrity: sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -6118,6 +6198,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm/0.15.7:
+    resolution: {integrity: sha512-JKgAHtMR5f75wJTeuNQbyznZZa+pjiUHV7sRZp42UNdyXC6TiUYMW/8z8yIBAr2Fpad8hM1royZKQisqPABPvQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm64/0.14.39:
     resolution: {integrity: sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==}
     engines: {node: '>=12'}
@@ -6137,6 +6226,15 @@ packages:
 
   /esbuild-linux-arm64/0.15.6:
     resolution: {integrity: sha512-aovDkclFa6C9EdZVBuOXxqZx83fuoq8097xZKhEPSygwuy4Lxs8J4anHG7kojAsR+31lfUuxzOo2tHxv7EiNHA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.15.7:
+    resolution: {integrity: sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -6170,6 +6268,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-mips64le/0.15.7:
+    resolution: {integrity: sha512-T7XKuxl0VpeFLCJXub6U+iybiqh0kM/bWOTb4qcPyDDwNVhLUiPcGdG2/0S7F93czUZOKP57YiLV8YQewgLHKw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-ppc64le/0.14.39:
     resolution: {integrity: sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==}
     engines: {node: '>=12'}
@@ -6189,6 +6296,15 @@ packages:
 
   /esbuild-linux-ppc64le/0.15.6:
     resolution: {integrity: sha512-z6w6gsPH/Y77uchocluDC8tkCg9rfkcPTePzZKNr879bF4tu7j9t255wuNOCE396IYEGxY7y8u2HJ9i7kjCLVw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.15.7:
+    resolution: {integrity: sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -6222,6 +6338,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-riscv64/0.15.7:
+    resolution: {integrity: sha512-uUJsezbswAYo/X7OU/P+PuL/EI9WzxsEQXDekfwpQ23uGiooxqoLFAPmXPcRAt941vjlY9jtITEEikWMBr+F/g==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-s390x/0.14.39:
     resolution: {integrity: sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==}
     engines: {node: '>=12'}
@@ -6241,6 +6366,15 @@ packages:
 
   /esbuild-linux-s390x/0.15.6:
     resolution: {integrity: sha512-OZeeDu32liefcwAE63FhVqM4heWTC8E3MglOC7SK0KYocDdY/6jyApw0UDkDHlcEK9mW6alX/SH9r3PDjcCo/Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.15.7:
+    resolution: {integrity: sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -6274,6 +6408,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-netbsd-64/0.15.7:
+    resolution: {integrity: sha512-yVc4Wz+Pu3cP5hzm5kIygNPrjar/v5WCSoRmIjCPWfBVJkZNb5brEGKUlf+0Y759D48BCWa0WHrWXaNy0DULTQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-openbsd-64/0.14.39:
     resolution: {integrity: sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==}
     engines: {node: '>=12'}
@@ -6300,6 +6443,30 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-openbsd-64/0.15.7:
+    resolution: {integrity: sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-plugin-solid/0.4.2_bwcvipldrmzlcczfdyw74a3qbi:
+    resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
+    peerDependencies:
+      esbuild: '>=0.12'
+      solid-js: '>= 1.0'
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
+      babel-preset-solid: 1.4.8_@babel+core@7.18.10
+      esbuild: 0.15.7
+      solid-js: 1.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /esbuild-plugin-solid/0.4.2_kdtxu7zkztxu5bgafyqjgjsfvy:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
@@ -6310,21 +6477,6 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
       babel-preset-solid: 1.4.8_@babel+core@7.18.10
       esbuild: 0.14.54
-      solid-js: 1.5.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /esbuild-plugin-solid/0.4.2_xybkfzdsahgdimry3w5c4gfvbu:
-    resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
-    peerDependencies:
-      esbuild: '>=0.12'
-      solid-js: '>= 1.0'
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
-      babel-preset-solid: 1.4.8_@babel+core@7.18.10
-      esbuild: 0.15.6
       solid-js: 1.5.4
     transitivePeerDependencies:
       - supports-color
@@ -6349,6 +6501,15 @@ packages:
 
   /esbuild-sunos-64/0.15.6:
     resolution: {integrity: sha512-1ceefLdPWcd1nW/ZLruPEYxeUEAVX0YHbG7w+BB4aYgfknaLGotI/ZvPWUZpzhC8l1EybrVlz++lm3E6ODIJOg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.15.7:
+    resolution: {integrity: sha512-8CDI1aL/ts0mDGbWzjEOGKXnU7p3rDzggHSBtVryQzkSOsjCHRVe0iFYUuhczlxU1R3LN/E7HgUO4NXzGGP/Ag==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -6382,6 +6543,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-32/0.15.7:
+    resolution: {integrity: sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-64/0.14.39:
     resolution: {integrity: sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==}
     engines: {node: '>=12'}
@@ -6408,6 +6578,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.15.7:
+    resolution: {integrity: sha512-7MI08Ec2sTIDv+zH6StNBKO+2hGUYIT42GmFyW6MBBWWtJhTcQLinKS6ldIN1d52MXIbiJ6nXyCJ+LpL4jBm3Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.14.39:
     resolution: {integrity: sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==}
     engines: {node: '>=12'}
@@ -6427,6 +6606,15 @@ packages:
 
   /esbuild-windows-arm64/0.15.6:
     resolution: {integrity: sha512-DB3G2x9OvFEa00jV+OkDBYpufq5x/K7a6VW6E2iM896DG4ZnAvJKQksOsCPiM1DUaa+DrijXAQ/ZOcKAqf/3Hg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.15.7:
+    resolution: {integrity: sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -6523,6 +6711,35 @@ packages:
       esbuild-windows-32: 0.15.6
       esbuild-windows-64: 0.15.6
       esbuild-windows-arm64: 0.15.6
+    dev: true
+
+  /esbuild/0.15.7:
+    resolution: {integrity: sha512-7V8tzllIbAQV1M4QoE52ImKu8hT/NLGlGXkiDsbEU5PS6K8Mn09ZnYoS+dcmHxOS9CRsV4IRAMdT3I67IyUNXw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/linux-loong64': 0.15.7
+      esbuild-android-64: 0.15.7
+      esbuild-android-arm64: 0.15.7
+      esbuild-darwin-64: 0.15.7
+      esbuild-darwin-arm64: 0.15.7
+      esbuild-freebsd-64: 0.15.7
+      esbuild-freebsd-arm64: 0.15.7
+      esbuild-linux-32: 0.15.7
+      esbuild-linux-64: 0.15.7
+      esbuild-linux-arm: 0.15.7
+      esbuild-linux-arm64: 0.15.7
+      esbuild-linux-mips64le: 0.15.7
+      esbuild-linux-ppc64le: 0.15.7
+      esbuild-linux-riscv64: 0.15.7
+      esbuild-linux-s390x: 0.15.7
+      esbuild-netbsd-64: 0.15.7
+      esbuild-openbsd-64: 0.15.7
+      esbuild-sunos-64: 0.15.7
+      esbuild-windows-32: 0.15.7
+      esbuild-windows-64: 0.15.7
+      esbuild-windows-arm64: 0.15.7
     dev: true
 
   /escalade/3.1.1:
@@ -7444,7 +7661,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-cli/28.1.3_g3ob4elhesv7uyo2jbxkqs7hje:
+  /jest-cli/28.1.3_gsb7asu77en4txj3es3i65pxci:
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -7461,7 +7678,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.3_g3ob4elhesv7uyo2jbxkqs7hje
+      jest-config: 28.1.3_gsb7asu77en4txj3es3i65pxci
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -7623,7 +7840,47 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_77qufrcolqt5x2bjepbsxfbcpy
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /jest-config/28.1.3_gsb7asu77en4txj3es3i65pxci:
+    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@jest/test-sequencer': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 18.7.14
+      babel-jest: 28.1.3_@babel+core@7.18.10
+      chalk: 4.1.2
+      ci-info: 3.3.2
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7980,7 +8237,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest/28.1.3_g3ob4elhesv7uyo2jbxkqs7hje:
+  /jest/28.1.3_gsb7asu77en4txj3es3i65pxci:
     resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -7993,7 +8250,7 @@ packages:
       '@jest/core': 28.1.3_ts-node@10.9.1
       '@jest/types': 28.1.3
       import-local: 3.1.0
-      jest-cli: 28.1.3_g3ob4elhesv7uyo2jbxkqs7hje
+      jest-cli: 28.1.3_gsb7asu77en4txj3es3i65pxci
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -8987,7 +9244,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.5
-      ts-node: 10.9.1_77qufrcolqt5x2bjepbsxfbcpy
+      ts-node: 10.9.1_tphhiizkxv2hzwkunblc3hbmra
       yaml: 1.10.2
     dev: true
 
@@ -9110,6 +9367,12 @@ packages:
     resolution: {integrity: sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /react-refresh/0.14.0:
+    resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+    optional: true
 
   /read-package-json-fast/2.0.3:
     resolution: {integrity: sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==}
@@ -10097,7 +10360,7 @@ packages:
       yargs-parser: 21.0.1
     dev: true
 
-  /ts-node/10.9.1_77qufrcolqt5x2bjepbsxfbcpy:
+  /ts-node/10.9.1_tphhiizkxv2hzwkunblc3hbmra:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10116,7 +10379,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.0.0
+      '@types/node': 18.7.14
       acorn: 8.7.1
       acorn-walk: 8.2.0
       arg: 4.1.3


### PR DESCRIPTION
tracking, displaying and updating component props in the details side panel.

Closes #56 

![image](https://user-images.githubusercontent.com/24491503/188281424-d398a027-01ee-4ec4-b178-bb95d8b53a2f.png)

Requires https://github.com/solidjs/solid/pull/1204 to work.

TODO:
  - [x] parse the props in the tree walker
  - [x] reconcile props on the extension end
  - [x] display the props in the extension
  - [x] allow for collapsing nested prop values
  - [x] fix reconciliation of nested values (maybe tests are needed after all)
  - [x] send only prop values, instead of the whole details
  - [x] highlight hovered HTML elements
  - [x] improve props display styles
  - [x] add changeset