### PR TITLE
Inject and configure debugger with vite plugin

### DIFF
--- a/.changeset/yellow-apricots-develop.md
+++ b/.changeset/yellow-apricots-develop.md
@@ -1,0 +1,7 @@
+---
+'@solid-devtools/transform': minor
+'solid-devtools': patch
+'@solid-devtools/debugger': patch
+---
+
+Add ability to inject and configure debugger with vite plugin. (now the default way to setup devtools)

--- a/configs/tsup.config.ts
+++ b/configs/tsup.config.ts
@@ -29,7 +29,6 @@ export default ({
     const options: Options = {
       watch: config.watch,
       clean: config.watch ? false : true,
-      minify: config.watch ? false : true,
       treeshake: config.watch ? false : true,
       dts: {
         entry: [entry, ...mappedAdditionalEntries],

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -18,14 +18,14 @@
     "typescript": "^4.9.3",
     "unocss": "^0.47.6",
     "vite": "^3.2.4",
-    "vite-plugin-solid": "^2.3.10"
+    "vite-plugin-solid": "^2.3.10",
+    "solid-devtools": "workspace:^0.24.1"
   },
   "dependencies": {
     "@solid-devtools/debugger": "workspace:^0.17.0",
     "@solid-devtools/logger": "workspace:^0.5.4",
     "@solid-devtools/overlay": "workspace:^0.4.1",
     "@solid-primitives/timer": "^1.3.4",
-    "solid-devtools": "workspace:^0.24.1",
     "solid-js": "^1.6.2"
   }
 }

--- a/examples/sandbox/src/devtools.ts
+++ b/examples/sandbox/src/devtools.ts
@@ -1,9 +1,4 @@
 import { attachDevtoolsOverlay } from '@solid-devtools/overlay'
-import { useLocator } from '@solid-devtools/debugger'
-
-useLocator({
-  targetIDE: 'vscode',
-})
 
 !process.env.EXT &&
   attachDevtoolsOverlay({

--- a/examples/sandbox/src/devtools.ts
+++ b/examples/sandbox/src/devtools.ts
@@ -1,4 +1,3 @@
-import 'solid-devtools'
 import { attachDevtoolsOverlay } from '@solid-devtools/overlay'
 import { useLocator } from '@solid-devtools/debugger'
 

--- a/examples/sandbox/vite.config.ts
+++ b/examples/sandbox/vite.config.ts
@@ -1,20 +1,24 @@
 import { defineConfig } from 'vite'
-import solidPlugin from 'vite-plugin-solid'
-import devtoolsPlugin from '@solid-devtools/transform'
+import solid from 'vite-plugin-solid'
+import devtools from '@solid-devtools/transform'
 import Unocss from 'unocss/vite'
 
 export default defineConfig(config => {
   const usingExtension = process.env.EXT === 'true' || process.env.EXT === '1'
 
+  console.log(devtools)
+
   return {
     plugins: [
-      devtoolsPlugin({
-        // wrapStores: true,
-        jsxLocation: true,
-        componentLocation: true,
-        name: true,
+      devtools({
+        autoname: true,
+        locator: {
+          targetIDE: 'vscode',
+          jsxLocation: true,
+          componentLocation: true,
+        },
       }),
-      solidPlugin({ hot: true, dev: true }),
+      solid({ hot: true, dev: true }),
       Unocss(),
     ],
     define: {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,7 @@
   "contributors": [],
   "scripts": {
     "dev:ext": "pnpm -dir packages/extension run dev",
-    "dev:client": "pnpm -dir packages/ext-client run dev",
-    "dev:shared": "pnpm -dir packages/shared run dev",
-    "dev:debugger": "pnpm -dir packages/debugger run dev",
-    "dev:frontend": "pnpm -dir packages/frontend run dev",
-    "dev:overlay": "pnpm -dir packages/overlay run dev",
+    "dev:transform": "pnpm -dir packages/transform run dev",
     "dev": "pnpm run -r --parallel --filter ./packages/* --filter !./packages/extension --filter !transform dev",
     "sandbox": "pnpm -dir examples/sandbox run dev",
     "sandbox:ext": "pnpm -dir examples/sandbox run dev:ext",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "@solid-devtools/shared": "workspace:^0.10.3",
-    "@solid-devtools/transform": "workspace:^0.9.0",
     "@solid-primitives/bounds": "^0.0.105",
     "@solid-primitives/cursor": "^0.0.103",
     "@solid-primitives/event-bus": "^0.1.3",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -31,28 +31,66 @@
   "main": "./dist/server.cjs",
   "module": "./dist/server.js",
   "types": "./dist/index.d.ts",
+  "browser": {
+    "./dist/server.cjs": "./dist/index.cjs",
+    "./dist/server.js": "./dist/index.js"
+  },
   "exports": {
     ".": {
+      "worker": {
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
+        "require": "./dist/server.cjs"
+      },
       "browser": {
         "development": {
-          "import": "./dist/index.js",
+          "import": {
+            "types": "./types/index.d.ts",
+            "default": "./dist/index.js"
+          },
           "require": "./dist/index.cjs"
         },
-        "import": "./dist/server.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
+        "require": "./dist/server.cjs"
+      },
+      "deno": {
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
+        "require": "./dist/server.cjs"
+      },
+      "node": {
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
         "require": "./dist/server.cjs"
       },
       "development": {
-        "import": "./dist/index.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
         "require": "./dist/index.cjs"
       },
-      "import": "./dist/server.js",
-      "require": "./dist/server.cjs",
-      "types": "./dist/index.d.ts"
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/server.js"
+      },
+      "require": "./dist/server.cjs"
     },
     "./types": {
-      "import": "./dist/types.js",
-      "require": "./dist/types.cjs",
-      "types": "./dist/types.d.ts"
+      "import": {
+        "types": "./types/types.d.ts",
+        "default": "./dist/types.js"
+      },
+      "require": "./dist/types.cjs"
     }
   },
   "typesVersions": {

--- a/packages/debugger/src/index.ts
+++ b/packages/debugger/src/index.ts
@@ -42,23 +42,6 @@ export {
 
 export { markComponentLoc } from './locator'
 
-export type {
-  LocatorOptions,
-  TargetIDE,
-  TargetURLFunction,
-  HighlightElementPayload,
-} from './locator'
-
-export type {
-  InspectorUpdate,
-  SetInspectedNodeData,
-  ToggleInspectedValueData,
-  ProxyPropsUpdate,
-  StoreNodeUpdate,
-  ValueNodeUpdate,
-} from './inspector'
-
 import plugin from './main/plugin'
 export const useDebugger = plugin.useDebugger
 export const useLocator = plugin.useLocator
-export type { BatchComputationUpdatesHandler } from './main/plugin'

--- a/packages/debugger/src/inspector/index.ts
+++ b/packages/debugger/src/inspector/index.ts
@@ -6,9 +6,10 @@ import { NodeIDMap } from '../main/utils'
 import { DebuggerEventHub } from '../main/plugin'
 import { findOwnerById } from '../main/roots'
 import { makeSolidUpdateListener } from '../main/update'
-import { encodeValue, EncodedValue } from './serialize'
+import { encodeValue } from './serialize'
 import { observeStoreNode, setOnStoreNodeUpdate, StoreNodeProperty, StoreUpdateData } from './store'
 import { clearOwnerObservers, collectOwnerDetails, ValueNodeMap } from './inspector'
+import { EncodedValue } from './types'
 
 export type ValueNodeUpdate = [id: ValueItemID, value: EncodedValue[]]
 

--- a/packages/debugger/src/inspector/serialize.ts
+++ b/packages/debugger/src/inspector/serialize.ts
@@ -1,47 +1,16 @@
 import { unwrap } from 'solid-js/store'
-import { NodeID, Core } from '../types'
+import {
+  NodeID,
+  Core,
+  EncodedValue,
+  ValueType,
+  INFINITY,
+  NEGATIVE_INFINITY,
+  NAN,
+  UNDEFINED,
+} from '../types'
 import { isStoreNode, NodeIDMap } from '../main/utils'
 import { FalsyValue } from '@solid-primitives/utils'
-
-export const INFINITY = 'Infinity'
-export const NEGATIVE_INFINITY = 'NegativeInfinity'
-export const NAN = 'NaN'
-export const UNDEFINED = 'undefined'
-
-export enum ValueType {
-  Number = 'number',
-  Boolean = 'boolean',
-  String = 'string',
-  Null = 'null',
-  Symbol = 'symbol',
-  Array = 'array',
-  Object = 'object',
-  Function = 'function',
-  Getter = 'getter',
-  Element = 'element',
-  Instance = 'instance',
-  Store = 'store',
-}
-
-type EncodedValueDataMap = {
-  [ValueType.Null]: null | typeof UNDEFINED
-  [ValueType.Array]: number | number[]
-  [ValueType.Object]: number | { [key: string]: number }
-  [ValueType.Number]: number | typeof INFINITY | typeof NEGATIVE_INFINITY | typeof NAN
-  [ValueType.Boolean]: boolean
-  [ValueType.String]: string
-  [ValueType.Symbol]: string
-  [ValueType.Function]: string
-  [ValueType.Getter]: string
-  [ValueType.Element]: `${NodeID}:${string}`
-  [ValueType.Instance]: string
-  [ValueType.Store]: `${NodeID}:${number}`
-}
-
-export type EncodedValueMap = {
-  [T in ValueType]: [type: T, data: EncodedValueDataMap[T]]
-}
-export type EncodedValue<T extends ValueType = ValueType> = EncodedValueMap[T]
 
 // globals
 let Deep: boolean

--- a/packages/debugger/src/inspector/test/serialize.test.ts
+++ b/packages/debugger/src/inspector/test/serialize.test.ts
@@ -1,6 +1,6 @@
 import { createMutable, createStore } from 'solid-js/store'
 import { describe, test, expect, vi } from 'vitest'
-import { EncodedValue, INFINITY, NAN, NEGATIVE_INFINITY, UNDEFINED, ValueType } from '../serialize'
+import { EncodedValue, INFINITY, NAN, NEGATIVE_INFINITY, UNDEFINED, ValueType } from '../types'
 import { encodeValue } from '../serialize'
 import { NodeIDMap } from '../../main/utils'
 import { Truthy } from '@solid-primitives/utils'

--- a/packages/debugger/src/inspector/types.ts
+++ b/packages/debugger/src/inspector/types.ts
@@ -1,0 +1,50 @@
+import type { NodeID } from '../main/types'
+
+export const INFINITY = 'Infinity'
+export const NEGATIVE_INFINITY = 'NegativeInfinity'
+export const NAN = 'NaN'
+export const UNDEFINED = 'undefined'
+
+export enum ValueType {
+  Number = 'number',
+  Boolean = 'boolean',
+  String = 'string',
+  Null = 'null',
+  Symbol = 'symbol',
+  Array = 'array',
+  Object = 'object',
+  Function = 'function',
+  Getter = 'getter',
+  Element = 'element',
+  Instance = 'instance',
+  Store = 'store',
+}
+
+type EncodedValueDataMap = {
+  [ValueType.Null]: null | typeof UNDEFINED
+  [ValueType.Array]: number | number[]
+  [ValueType.Object]: number | { [key: string]: number }
+  [ValueType.Number]: number | typeof INFINITY | typeof NEGATIVE_INFINITY | typeof NAN
+  [ValueType.Boolean]: boolean
+  [ValueType.String]: string
+  [ValueType.Symbol]: string
+  [ValueType.Function]: string
+  [ValueType.Getter]: string
+  [ValueType.Element]: `${NodeID}:${string}`
+  [ValueType.Instance]: string
+  [ValueType.Store]: `${NodeID}:${number}`
+}
+
+export type EncodedValueMap = {
+  [T in ValueType]: [type: T, data: EncodedValueDataMap[T]]
+}
+export type EncodedValue<T extends ValueType = ValueType> = EncodedValueMap[T]
+
+export type {
+  InspectorUpdate,
+  SetInspectedNodeData,
+  ToggleInspectedValueData,
+  ValueNodeUpdate,
+  StoreNodeUpdate,
+  ProxyPropsUpdate,
+} from '.'

--- a/packages/debugger/src/locator/findComponent.ts
+++ b/packages/debugger/src/locator/findComponent.ts
@@ -1,10 +1,7 @@
-import {
-  LocationAttr,
-  LOCATION_ATTRIBUTE_NAME,
-  WINDOW_PROJECTPATH_PROPERTY,
-} from '@solid-devtools/transform/types'
 import { isWindows } from '@solid-primitives/platform'
-import { NodeID } from '../types'
+import { LOCATION_ATTRIBUTE_NAME, NodeID, WINDOW_PROJECTPATH_PROPERTY } from '../types'
+
+export type LocationAttr = `${string}:${number}:${number}`
 
 export type LocatorComponent = {
   id: NodeID

--- a/packages/debugger/src/locator/index.ts
+++ b/packages/debugger/src/locator/index.ts
@@ -8,7 +8,7 @@ import {
   createSignal,
 } from 'solid-js'
 import { makeEventListener } from '@solid-primitives/event-listener'
-import { createKeyHold, KbdKey } from '@solid-primitives/keyboard'
+import { createKeyHold } from '@solid-primitives/keyboard'
 import { onRootCleanup } from '@solid-primitives/utils'
 import { createSimpleEmitter } from '@solid-primitives/event-bus'
 import { atom, defer, makeHoverElementListener } from '@solid-devtools/shared/primitives'
@@ -16,43 +16,18 @@ import { asArray, warn } from '@solid-devtools/shared/utils'
 import {
   getLocationAttr,
   getSourceCodeData,
+  LocationAttr,
   LocatorComponent,
   openSourceCode,
-  SourceCodeData,
   TargetIDE,
   TargetURLFunction,
 } from './findComponent'
 import { enableRootsAutoattach, createInternalRoot } from '../main/roots'
 import { attachElementOverlay } from './ElementOverlay'
-import { LocationAttr, NodeID } from '../types'
+import { NodeID } from '../main/types'
+import { ClickMiddleware, HighlightElementPayload, LocatorOptions } from './types'
 import * as registry from '../main/componentRegistry'
 import { scheduleIdle } from '@solid-primitives/scheduled'
-
-export type { LocatorComponent, TargetIDE, TargetURLFunction } from './findComponent'
-
-export type LocatorOptions = {
-  /** Choose in which IDE the component source code should be revealed. */
-  targetIDE?: false | TargetIDE | TargetURLFunction
-  /** Holding which key should enable the locator overlay? */
-  key?: KbdKey
-}
-
-type HighlightElementPayloads = {
-  elementNode: { componentId: NodeID; elementId: NodeID }
-  componentNode: { componentId: NodeID }
-  element: { elementId: NodeID }
-}
-export type HighlightElementPayload =
-  | {
-      [K in keyof HighlightElementPayloads]: HighlightElementPayloads[K] & { type: K }
-    }[keyof HighlightElementPayloads]
-  | null
-
-export type ClickMiddleware = (
-  event: MouseEvent | CustomEvent,
-  component: LocatorComponent,
-  data: SourceCodeData | undefined,
-) => void
 
 export { markComponentLoc } from './markComponent'
 
@@ -223,8 +198,10 @@ export function createLocator({
       if (locatorUsed) return warn('useLocator can be called only once.')
       locatorUsed = true
       if (options.targetIDE) targetIDE = options.targetIDE
-      const isHoldingKey = createKeyHold(options.key ?? 'Alt', { preventDefault: true })
-      enabledByPressingSignal(() => isHoldingKey)
+      if (options.key !== false) {
+        const isHoldingKey = createKeyHold(options.key ?? 'Alt', { preventDefault: true })
+        enabledByPressingSignal(() => isHoldingKey)
+      }
     })
   }
 

--- a/packages/debugger/src/locator/markComponent.ts
+++ b/packages/debugger/src/locator/markComponent.ts
@@ -1,6 +1,6 @@
 import { getOwner, getOwnerType } from '../main/utils'
-import { LocationAttr, MARK_COMPONENT_FN_NAME } from '@solid-devtools/transform/types'
 import { NodeType, Solid } from '../types'
+import { LocationAttr } from './findComponent'
 
 export function markComponentLoc(location: LocationAttr): void {
   let owner = getOwner()
@@ -9,6 +9,3 @@ export function markComponentLoc(location: LocationAttr): void {
   if (type === NodeType.Component) (owner as Solid.Component).location = location
   else if (type === NodeType.Refresh) (owner.owner as Solid.Component).location = location
 }
-
-// transform uses this global function to mark components
-;(globalThis as any)[MARK_COMPONENT_FN_NAME] = markComponentLoc

--- a/packages/debugger/src/locator/types.ts
+++ b/packages/debugger/src/locator/types.ts
@@ -1,0 +1,43 @@
+import type { KbdKey } from '@solid-primitives/keyboard'
+import type { NodeID } from '../main/types'
+import type {
+  LocatorComponent,
+  SourceCodeData,
+  TargetIDE,
+  TargetURLFunction,
+} from './findComponent'
+
+export type { LocationAttr, LocatorComponent, TargetIDE, TargetURLFunction } from './findComponent'
+
+export type LocatorOptions = {
+  /** Choose in which IDE the component source code should be revealed. */
+  targetIDE?: false | TargetIDE | TargetURLFunction
+  /**
+   * Holding which key should enable the locator overlay?
+   * @default 'Alt'
+   */
+  key?: false | KbdKey
+}
+
+type HighlightElementPayloads = {
+  elementNode: { componentId: NodeID; elementId: NodeID }
+  componentNode: { componentId: NodeID }
+  element: { elementId: NodeID }
+}
+export type HighlightElementPayload =
+  | {
+      [K in keyof HighlightElementPayloads]: HighlightElementPayloads[K] & { type: K }
+    }[keyof HighlightElementPayloads]
+  | null
+
+export type ClickMiddleware = (
+  event: MouseEvent | CustomEvent,
+  component: LocatorComponent,
+  data: SourceCodeData | undefined,
+) => void
+
+// used by the transform
+export const WINDOW_PROJECTPATH_PROPERTY = '$sdt_projectPath'
+export const LOCATION_ATTRIBUTE_NAME = 'data-source-loc'
+export const MARK_COMPONENT = `markComponentLoc`
+export const USE_LOCATOR = `useLocator`

--- a/packages/debugger/src/main/types.ts
+++ b/packages/debugger/src/main/types.ts
@@ -1,5 +1,5 @@
-import type { LocationAttr } from '@solid-devtools/transform/types'
-import type { EncodedValue } from '../inspector/serialize'
+import type { EncodedValue } from '../inspector/types'
+import type { LocationAttr } from '../locator/findComponent'
 import { NodeType, $SDT_ID } from './constants'
 
 export type NodeID = string & {}

--- a/packages/debugger/src/types.ts
+++ b/packages/debugger/src/types.ts
@@ -1,14 +1,6 @@
-export type { LocationAttr } from '@solid-devtools/transform/types'
-export type { EncodedValue, EncodedValueMap } from './inspector/serialize'
-export { ValueType, INFINITY, NAN, NEGATIVE_INFINITY, UNDEFINED } from './inspector/serialize'
 export * from './main/types'
 export * from './main/constants'
-export type {
-  InspectorUpdate,
-  SetInspectedNodeData,
-  ToggleInspectedValueData,
-  ProxyPropsUpdate,
-  StoreNodeUpdate,
-  ValueNodeUpdate,
-  HighlightElementPayload,
-} from '.'
+
+export * from './inspector/types'
+
+export * from './locator/types'

--- a/packages/ext-client/README.md
+++ b/packages/ext-client/README.md
@@ -24,54 +24,9 @@ yarn add -D solid-devtools
 pnpm add -D solid-devtools
 ```
 
-### Import the script
+### Usage
 
-All you need to do is import the devtools script in your app entry file, and the debugger will automatically find roots in your app and track them.
-
-```ts
-import 'solid-devtools'
-// and that's it!
-```
-
-### Using the chrome extension
-
-Importing the `solid-devtools` package will connect your Solid application to the [chrome extension](../extension#readme).
-
-[**Follow this guide to use the extension**](../extension#getting-started)
-
-### Using the locator package
-
-The `solid-devtools` package comes with the locator feature included. It's not neccessary to use it, but you can.
-
-```ts
-import { useLocator } from 'solid-devtools'
-
-useLocator({
-  targetIDE: 'vscode',
-})
-```
-
-[**Follow this locator guide to know more**](../debugger#Using-Locator)
-
-### Enabling the Babel plugin
-
-`solid-devtools` reexports the [babel plugin](../transform#readme) as a vite plugin.
-
-To enable it you need to add it to plugins array in your `.vite.config.js` file:
-
-```ts
-// vite.config.ts
-
-import { defineConfig } from 'vite'
-import solid from 'vite-plugin-solid'
-import devtools from 'solid-devtools/vite'
-
-export default defineConfig({
-  plugins: [devtools(), solid()],
-})
-```
-
-[**See transform options**](https://github.com/thetarnav/solid-devtools/tree/main/packages/transform#Options)
+For the usage guide, please refer to the [extension documentation](../extension#Getting-started) as it is the intended way to use the library.
 
 ## Changelog
 

--- a/packages/ext-client/README.md
+++ b/packages/ext-client/README.md
@@ -17,11 +17,11 @@ The main client library. It reexports the most [important tools](<(https://githu
 ### Installation
 
 ```bash
-npm i solid-devtools
+npm i -D solid-devtools
 # or
-yarn add solid-devtools
+yarn add -D solid-devtools
 # or
-pnpm add solid-devtools
+pnpm add -D solid-devtools
 ```
 
 ### Import the script

--- a/packages/ext-client/package.json
+++ b/packages/ext-client/package.json
@@ -32,33 +32,73 @@
   "main": "./dist/server.cjs",
   "module": "./dist/server.js",
   "types": "./dist/index.d.ts",
+  "browser": {
+    "./dist/server.cjs": "./dist/index.cjs",
+    "./dist/server.js": "./dist/index.js"
+  },
   "exports": {
     ".": {
+      "worker": {
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
+        "require": "./dist/server.cjs"
+      },
       "browser": {
         "development": {
-          "import": "./dist/index.js",
+          "import": {
+            "types": "./types/index.d.ts",
+            "default": "./dist/index.js"
+          },
           "require": "./dist/index.cjs"
         },
-        "import": "./dist/server.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
+        "require": "./dist/server.cjs"
+      },
+      "deno": {
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
+        "require": "./dist/server.cjs"
+      },
+      "node": {
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
         "require": "./dist/server.cjs"
       },
       "development": {
-        "import": "./dist/index.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/server.js"
+        },
         "require": "./dist/index.cjs"
       },
-      "import": "./dist/server.js",
-      "require": "./dist/server.cjs",
-      "types": "./dist/index.d.ts"
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/server.js"
+      },
+      "require": "./dist/server.cjs"
     },
     "./vite": {
-      "import": "./dist/vite.js",
-      "require": "./dist/vite.cjs",
-      "types": "./dist/vite.d.ts"
+      "import": {
+        "types": "./types/vite.d.ts",
+        "default": "./dist/vite.js"
+      },
+      "require": "./dist/vite.cjs"
     },
     "./bridge": {
-      "import": "./dist/bridge.js",
-      "require": "./dist/bridge.cjs",
-      "types": "./dist/bridge.d.ts"
+      "import": {
+        "types": "./types/bridge.d.ts",
+        "default": "./dist/bridge.js"
+      },
+      "require": "./dist/bridge.cjs"
     }
   },
   "typesVersions": {

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -36,37 +36,20 @@ If you think about the Chrome Extension as a **Frontend**, then the [**"solid-de
 Install the following package:
 
 ```bash
-npm i solid-devtools
+npm i -D solid-devtools
 # or
-yarn add solid-devtools
+yarn add -D solid-devtools
 # or
-pnpm add solid-devtools
+pnpm add -D solid-devtools
 ```
 
 _(you can install is as a dev dependency too, but it has a runtime—which is removed in production build)_
 
 As the extension requires both the extension and the library to work, you need to watchout for version mismatches. The extension will warn you if the library version is different than the one expected by the extension.
 
-### 3. Import the script
+### 3. Add devtools vite plugin
 
-Import `"solid-devtools"` package in your app entry file. (It's best if the script runs before any application code is executed)
-
-```ts
-// will automatically find and track all roots in your application
-// also setups the extension adapter
-import 'solid-devtools'
-```
-
-You can also use the Locator pacage here. It now is integrated with the extension. More on that [here](https://github.com/thetarnav/solid-devtools/tree/main/packages/locator#readme).
-
-```ts
-import { useLocator } from 'solid-devtools'
-useLocator()
-```
-
-### 4. Add vite plugin _(Optional)_
-
-The vite plugin is not necessary for the devtools to work, but enabling some of the options, such as `"name"`, will improve the debugging experience or enable additional features.
+The [vite plugin](../transform#readme) is a way to configure the transform options and add debugger script to the page. Enabling transforms are not necessary for the devtools to work, but the debugger script needs to be present to analyse you solid application. Enabling some of the options, such as `"name"`, will improve the debugging experience or enable additional features.
 
 ```ts
 // vite.config.ts
@@ -78,8 +61,12 @@ import devtools from 'solid-devtools/vite'
 export default defineConfig({
   plugins: [
     devtools({
+      // required:
+      injectDebugger: true,
+      // optional options:
       name: true,
       componentLocation: true,
+      jsxLocation: true,
     }),
     solid(),
   ],
@@ -88,7 +75,7 @@ export default defineConfig({
 
 [**>> More about transform options**](https://github.com/thetarnav/solid-devtools/tree/main/packages/transform#options)
 
-### 5. Run the app and play with the devtools!
+### 4. Run the app and play with the devtools!
 
 That's it! A new **"Solid"** panel should appear in your Chrome Devtools.
 
@@ -103,13 +90,6 @@ If you are interested in the extension's development, see the [Plans for Devtool
 This Stackblitz demo is setup to work with the extension.
 
 [**See this Stackblitz demo.**](https://stackblitz.com/edit/solid-devtools-demo?file=src%2Fmain.tsx)
-
-## Acknowledgements
-
-The content and examples of extension docs are inspired by following articles:
-
-- [**Taking SolidJS Dev-Tools for a Spin**](https://dev.to/mbarzeev/taking-solidjs-dev-tools-for-a-spin-44m2)
-- [**Using SolidJS Dev-Tools Locator Feature**](https://dev.to/mbarzeev/using-solidjs-dev-tools-locator-feature-1445)
 
 ## Changelog
 

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -49,7 +49,7 @@ As the extension requires both the extension and the library to work, you need t
 
 ### 3. Add devtools vite plugin
 
-The [vite plugin](../transform#readme) is a way to configure the transform options and add debugger script to the page. Enabling transforms are not necessary for the devtools to work, but the debugger script needs to be present to analyse you solid application. Enabling some of the options, such as `"name"`, will improve the debugging experience or enable additional features.
+All you need to do to get the debugger working, is include the vite plugin from `"solid-devtools/vite"` in your vite config. The [vite plugin](../transform#readme) is a way to configure the transform options and add debugger script to the page. Enabling transforms are not necessary for the devtools to work, but the debugger script needs to be present to analyse you solid application. Enabling some of the options, such as `"autoname"`, will improve the debugging experience or enable additional features.
 
 ```ts
 // vite.config.ts
@@ -61,12 +61,8 @@ import devtools from 'solid-devtools/vite'
 export default defineConfig({
   plugins: [
     devtools({
-      // required:
-      injectDebugger: true,
-      // optional options:
-      name: true,
-      componentLocation: true,
-      jsxLocation: true,
+      /* additional options */
+      autoname: true, // e.g. enable autoname
     }),
     solid(),
   ],
@@ -75,7 +71,28 @@ export default defineConfig({
 
 [**>> More about transform options**](https://github.com/thetarnav/solid-devtools/tree/main/packages/transform#options)
 
-### 4. Run the app and play with the devtools!
+### 4. Using component locator (Optional)
+
+_Debugger feature inspired by [LocatorJS](https://www.locatorjs.com)_
+
+Locator let's you locate components on the page, and go to their source code in your IDE.
+
+```ts
+// vite.config.ts
+
+devtools({
+  // pass `true` or an object with options
+  locator: {
+    targetIDE: 'vscode',
+    componentLocation: true,
+    jsxLocation: true,
+  },
+})
+```
+
+[**Follow this locator guide to know more**](../debugger#Using-Locator)
+
+### 5. Run the app and play with the devtools!
 
 That's it! A new **"Solid"** panel should appear in your Chrome Devtools.
 

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -19,11 +19,11 @@ It can do very useful things for you: Wrap stores to let the debugger observe th
 ### Installation
 
 ```bash
-npm i @solid-devtools/transform
+npm i -D @solid-devtools/transform
 # or
-yarn add @solid-devtools/transform
+yarn add -D @solid-devtools/transform
 # or
-pnpm i @solid-devtools/transform
+pnpm i -D @solid-devtools/transform
 ```
 
 ### Setup
@@ -32,11 +32,11 @@ pnpm i @solid-devtools/transform
 // vite.config.ts
 
 import { defineConfig } from 'vite'
-import solidPlugin from 'vite-plugin-solid'
-import devtoolsPlugin from '@solid-devtools/transform'
+import solid from 'vite-plugin-solid'
+import devtools from '@solid-devtools/transform'
 
 export default defineConfig({
-  plugins: [devtoolsPlugin(), solidPlugin()],
+  plugins: [devtools(), solid()],
 })
 ```
 
@@ -46,18 +46,28 @@ All of the transforms are disabled by default—you need to pick what you want b
 
 ```ts
 interface DevtoolsPluginOptions {
+  /** Inject debugger script to the page */
+  injectDebugger?: boolean
+  /** Add automatic name when creating signals, memos, stores, or mutables */
   name?: boolean
-  componentLocation?: boolean
+  /** Inject location attributes to jsx templates */
   jsxLocation?: boolean
+  /** Inject location information to component declarations */
+  componentLocation?: boolean
 }
 
 // in vite.config.ts plugins array:
-devtoolsPlugin({
+devtools({
+  injectDebugger: true,
   name: true,
-  componentLocation: true,
   jsxLocation: true,
+  componentLocation: true,
 })
 ```
+
+#### `injectDebugger`
+
+Injects the [debugger](../debugger#readme) and [extension client](../ext-client#readme) script to the page. This is required to use the extension.
 
 #### `name`
 

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -42,46 +42,60 @@ export default defineConfig({
 
 ### Options
 
-All of the transforms are disabled by default—you need to pick what you want by enabling correlated option.
+By default the plugin will only inject the debugger and extension client script to the page. (If installed)
+
+All of the other transforms are disabled by default—you need to pick what you want by enabling correlated option.
 
 ```ts
 interface DevtoolsPluginOptions {
-  /** Inject debugger script to the page */
-  injectDebugger?: boolean
   /** Add automatic name when creating signals, memos, stores, or mutables */
-  name?: boolean
-  /** Inject location attributes to jsx templates */
-  jsxLocation?: boolean
-  /** Inject location information to component declarations */
-  componentLocation?: boolean
+  autoname?: boolean
+  locator?:
+    | boolean
+    | {
+        /** Choose in which IDE the component source code should be revealed. */
+        targetIDE?: Exclude<LocatorOptions['targetIDE'], TargetURLFunction>
+        /**
+         * Holding which key should enable the locator overlay?
+         * @default 'Alt'
+         */
+        key?: LocatorOptions['key']
+        /** Inject location attributes to jsx templates */
+        jsxLocation?: boolean
+        /** Inject location information to component declarations */
+        componentLocation?: boolean
+      }
 }
 
 // in vite.config.ts plugins array:
 devtools({
-  injectDebugger: true,
-  name: true,
-  jsxLocation: true,
-  componentLocation: true,
+  autoname: true,
+  locator: {
+    targetIDE: 'vscode',
+    key: 'Ctrl',
+    jsxLocation: true,
+    componentLocation: true,
+  },
 })
 ```
 
-#### `injectDebugger`
-
-Injects the [debugger](../debugger#readme) and [extension client](../ext-client#readme) script to the page. This is required to use the extension.
-
-#### `name`
+#### `autoname`
 
 This option adds automatic name to signals, memos, stores, and mutables. Those names will be visible in the devtools when inspecting.
 
 ![name-transform-example](https://user-images.githubusercontent.com/24491503/202861594-a18f34c0-bc30-4762-957a-9eb76a6b526c.png)
 
-#### `componentLocation`
+#### `locator`
+
+This option enables the [locator](../debugger#Using-component-locator) feature. The `key` and `targetIDE` are going to pe passed to `useLocator` function call.
+
+#### `locator.componentLocation`
 
 Inject location information to component functions. This will add a button in the devtools inspector panel, allowing you to go to the source code of the component.
 
 ![component-location-ui](https://user-images.githubusercontent.com/24491503/202861187-647b5792-fd8b-4fd2-9d26-2e6dee905fa9.png)
 
-#### `jsxLocation`
+#### `locator.jsxLocation`
 
 Inject location attributes to jsx templates. This is required for the debugger's [locator](https://github.com/thetarnav/solid-devtools/tree/main/packages/debugger#Using-component-locator) feature.
 

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -33,23 +33,11 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
-    "./types": {
-      "import": "./dist/types.js",
-      "require": "./dist/types.cjs",
-      "types": "./dist/types.d.ts"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "types": [
-        "./dist/types.d.ts"
-      ]
-    }
+    "require": "./dist/index.cjs"
   },
   "scripts": {
     "dev": "tsup --watch",
@@ -75,10 +63,11 @@
     "@babel/core": "^7.19.6",
     "@babel/plugin-syntax-typescript": "^7.18.6",
     "@babel/types": "^7.19.4",
-    "@solid-devtools/shared": "workspace:^0.10.1"
+    "@solid-devtools/shared": "workspace:^0.10.1",
+    "@solid-devtools/debugger": "workspace:^0.17.0"
   },
   "peerDependencies": {
     "solid-js": "^1.6.2",
-    "vite": "^2.2.3 || ^3.0.0"
+    "vite": "^2.2.3 || ^3.0.0 || ^4.0.0"
   }
 }

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -2,8 +2,17 @@ import { PluginItem, transformAsync } from '@babel/core'
 import { PluginOption } from 'vite'
 import jsxLocationPlugin from './location'
 import namePlugin from './name'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+
+const MAIN_CLIENT_MODULE = 'solid-devtools'
+const DEBUGGER_MODULE = '@solid-devtools/debugger'
+const INJECT_SCRIPT_ID = '__solid-devtools'
 
 export interface DevtoolsPluginOptions {
+  /** Inject debugger script to the page */
+  injectDebugger?: boolean
   /** Add automatic name when creating signals, memos, stores, or mutables */
   name?: boolean
   /** Inject location attributes to jsx templates */
@@ -18,17 +27,65 @@ function getFileExtension(filename: string): string {
 }
 
 // This export is used for configuration.
-export const devtoolsPlugin = (options: DevtoolsPluginOptions = {}): PluginOption => {
-  const { name = false, jsxLocation = false, componentLocation = false } = options
+export const devtoolsPlugin = (_options: DevtoolsPluginOptions = {}): PluginOption => {
+  const options = {
+    injectDebugger: false,
+    name: false,
+    jsxLocation: false,
+    componentLocation: false,
+    ..._options,
+  }
 
   let enablePlugin = false
   let projectRoot = process.cwd()
 
+  let runtimeInstalled: false | typeof MAIN_CLIENT_MODULE | typeof DEBUGGER_MODULE = false
+
   return {
     name: 'solid-devtools',
     enforce: 'pre',
+    config() {
+      try {
+        require(MAIN_CLIENT_MODULE)
+        runtimeInstalled = MAIN_CLIENT_MODULE
+      } catch (e) {
+        try {
+          require(DEBUGGER_MODULE)
+          runtimeInstalled = DEBUGGER_MODULE
+        } catch (e) {
+          // runtimeInstalled = false
+          // ! For some reason, this is not working. So will fallback to 'main' for now.
+          runtimeInstalled = MAIN_CLIENT_MODULE
+          // eslint-disable-next-line no-console
+          console.log(
+            `[solid-devtools]: Could not find "${MAIN_CLIENT_MODULE}" or "${DEBUGGER_MODULE}" module.`,
+          )
+        }
+      }
+    },
     configResolved(config) {
       enablePlugin = config.command === 'serve' && config.mode !== 'production'
+    },
+    transformIndexHtml() {
+      if (enablePlugin && runtimeInstalled && options.injectDebugger)
+        return [
+          {
+            tag: 'script',
+            attrs: { type: 'module', src: INJECT_SCRIPT_ID },
+            injectTo: 'body-prepend',
+          },
+        ]
+    },
+    load(id) {
+      // Inject runtime debugger script
+      if (
+        enablePlugin &&
+        runtimeInstalled &&
+        options.injectDebugger &&
+        (id === INJECT_SCRIPT_ID || id === `/${INJECT_SCRIPT_ID}`)
+      ) {
+        return `import '${runtimeInstalled}';`
+      }
     },
     async transform(source, id, transformOptions) {
       // production and server should be disabled
@@ -42,10 +99,12 @@ export const devtoolsPlugin = (options: DevtoolsPluginOptions = {}): PluginOptio
       const plugins: PluginItem[] = []
 
       // plugins that should only run on .tsx/.jsx files in development
-      if ((jsxLocation || componentLocation) && isJSX) {
-        plugins.push(jsxLocationPlugin({ jsx: jsxLocation, components: componentLocation }))
+      if ((options.jsxLocation || options.componentLocation) && isJSX) {
+        plugins.push(
+          jsxLocationPlugin({ jsx: options.jsxLocation, components: options.componentLocation }),
+        )
       }
-      if (name) {
+      if (options.name) {
         plugins.push(namePlugin)
       }
 

--- a/packages/transform/src/location.ts
+++ b/packages/transform/src/location.ts
@@ -4,9 +4,10 @@ import * as t from '@babel/types'
 import {
   LocationAttr,
   LOCATION_ATTRIBUTE_NAME,
-  MARK_COMPONENT_FN_NAME,
   WINDOW_PROJECTPATH_PROPERTY,
-} from './types'
+} from '@solid-devtools/debugger/types'
+
+export const MARK_COMPONENT_GLOBAL = `_$markComponentLoc`
 
 const cwd = process.cwd()
 
@@ -14,7 +15,7 @@ const projectPathAst = template(`globalThis.${WINDOW_PROJECTPATH_PROPERTY} = %%l
   loc: t.stringLiteral(cwd),
 }) as t.Statement
 
-const buildMarkComponent = template(`globalThis.${MARK_COMPONENT_FN_NAME}(%%loc%%);`) as (
+const buildMarkComponent = template(`globalThis.${MARK_COMPONENT_GLOBAL}(%%loc%%);`) as (
   ...args: Parameters<ReturnType<typeof template>>
 ) => t.Statement
 

--- a/packages/transform/src/types.ts
+++ b/packages/transform/src/types.ts
@@ -1,6 +1,0 @@
-export const MARK_COMPONENT_FN_NAME = `_$markComponentLoc`
-
-export const WINDOW_PROJECTPATH_PROPERTY = '$sdt_projectPath'
-export const LOCATION_ATTRIBUTE_NAME = 'data-source-loc'
-
-export type LocationAttr = `${string}:${number}:${number}`

--- a/packages/transform/test/location.test.ts
+++ b/packages/transform/test/location.test.ts
@@ -1,11 +1,10 @@
 import { assertTransform, cwd, file } from './setup'
 import { describe, test } from 'vitest'
-import getPlugin from '../src/location'
+import getPlugin, { MARK_COMPONENT_GLOBAL } from '../src/location'
 import {
   LOCATION_ATTRIBUTE_NAME,
-  MARK_COMPONENT_FN_NAME,
   WINDOW_PROJECTPATH_PROPERTY,
-} from '../src/types'
+} from '@solid-devtools/debugger/types'
 
 describe('location', () => {
   const testData: [
@@ -20,7 +19,7 @@ describe('location', () => {
   return <button>Click me</button>
 }`,
       `function Button(props) {
-  globalThis.${MARK_COMPONENT_FN_NAME}("${file}:1:0");
+  globalThis.${MARK_COMPONENT_GLOBAL}("${file}:1:0");
   return <button>Click me</button>;
 }
 globalThis.${WINDOW_PROJECTPATH_PROPERTY} = "${cwd}";`,
@@ -32,7 +31,7 @@ globalThis.${WINDOW_PROJECTPATH_PROPERTY} = "${cwd}";`,
   return <button>Click me</button>
 }`,
       `const Button = props => {
-  globalThis.${MARK_COMPONENT_FN_NAME}("${file}:1:6");
+  globalThis.${MARK_COMPONENT_GLOBAL}("${file}:1:6");
   return <button>Click me</button>;
 };
 globalThis.${WINDOW_PROJECTPATH_PROPERTY} = "${cwd}";`,

--- a/packages/transform/tsup.config.ts
+++ b/packages/transform/tsup.config.ts
@@ -1,5 +1,3 @@
 import defineConfig from '../../configs/tsup.config'
 
-export default defineConfig({
-  additionalEntries: ['types'],
-})
+export default defineConfig({})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,11 +78,11 @@ importers:
       '@solid-devtools/logger': link:../../packages/logger
       '@solid-devtools/overlay': link:../../packages/overlay
       '@solid-primitives/timer': 1.3.4_solid-js@1.6.5
-      solid-devtools: link:../../packages/ext-client
       solid-js: 1.6.5
     devDependencies:
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.5
       '@solid-devtools/transform': link:../../packages/transform
+      solid-devtools: link:../../packages/ext-client
       typescript: 4.9.4
       unocss: 0.47.6_vite@3.2.5
       vite: 3.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,7 +133,6 @@ importers:
   packages/debugger:
     specifiers:
       '@solid-devtools/shared': workspace:^0.10.3
-      '@solid-devtools/transform': workspace:^0.9.0
       '@solid-primitives/bounds': ^0.0.105
       '@solid-primitives/cursor': ^0.0.103
       '@solid-primitives/event-bus': ^0.1.3
@@ -146,7 +145,6 @@ importers:
       type-fest: ^3.2.0
     dependencies:
       '@solid-devtools/shared': link:../shared
-      '@solid-devtools/transform': link:../transform
       '@solid-primitives/bounds': 0.0.105_solid-js@1.6.5
       '@solid-primitives/cursor': 0.0.103_solid-js@1.6.5
       '@solid-primitives/event-bus': 0.1.4_solid-js@1.6.5
@@ -341,6 +339,7 @@ importers:
       '@babel/plugin-syntax-typescript': ^7.18.6
       '@babel/traverse': ^7.19.6
       '@babel/types': ^7.19.4
+      '@solid-devtools/debugger': workspace:^0.17.0
       '@solid-devtools/shared': workspace:^0.10.1
       '@types/babel__core': ^7.1.19
       '@types/babel__generator': ^7.6.4
@@ -354,6 +353,7 @@ importers:
       '@babel/core': 7.20.5
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.5
       '@babel/types': 7.20.5
+      '@solid-devtools/debugger': link:../debugger
       '@solid-devtools/shared': link:../shared
       solid-js: 1.6.5
     devDependencies:


### PR DESCRIPTION
Making the vite plugin the default way to set up devtools should improve the overall experience.
Removes the issue of "where should I import the debugger script?", etc.