### PR TITLE
Fix overlay type exports

### DIFF
--- a/.changeset/tame-berries-listen.md
+++ b/.changeset/tame-berries-listen.md
@@ -1,0 +1,5 @@
+---
+'@solid-devtools/overlay': patch
+---
+
+Fix type exports

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -30,10 +30,7 @@
     "module": "./dist/prod.js",
     "types": "./dist/types/index.d.ts",
     "exports": {
-        "browser": {
-            "development": "./dist/dev.js",
-            "default": "./dist/prod.js"
-        },
+        "types": "./dist/types/index.d.ts",
         "development": "./dist/dev.js",
         "default": "./dist/prod.js"
     },


### PR DESCRIPTION
Currently, the types are built but ignored by `tsc`:

```
src/main.tsx:11:39 - error TS7016: Could not find a declaration file for module '@solid-devtools/overlay'. '/home/n/Documents/stackable/stackable-admin/node_modules/@solid-devtools/overlay/dist/prod.js' implicitly has an 'any' type.
  There are types at '/home/n/Documents/stackable/stackable-admin/node_modules/@solid-devtools/overlay/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@solid-devtools/overlay' library may need to update its package.json or typings.

11 import { attachDevtoolsOverlay } from '@solid-devtools/overlay';
```

This PR registers them in the `package.json` so that they are picked up correctly.