### PR TITLE
Output source map from vite plugin

### DIFF
--- a/.changeset/nice-houses-tan.md
+++ b/.changeset/nice-houses-tan.md
@@ -1,0 +1,5 @@
+---
+'solid-devtools': minor
+---
+
+Output source map from vite plugin

--- a/examples/vite-plugin-ssr/package.json
+++ b/examples/vite-plugin-ssr/package.json
@@ -10,5 +10,8 @@
     "dependencies": {
         "solid-devtools": "workspace:^",
         "vite-plugin-ssr": "0.4.133"
+    },
+    "devDependencies": {
+        "vite-plugin-inspect": "^0.7.33"
     }
 }

--- a/examples/vite-plugin-ssr/vite.config.ts
+++ b/examples/vite-plugin-ssr/vite.config.ts
@@ -2,6 +2,7 @@ import devtools from 'solid-devtools/vite'
 import { defineConfig } from 'vite'
 import solid from 'vite-plugin-solid'
 import ssr from 'vite-plugin-ssr/plugin'
+import inspect from 'vite-plugin-inspect'
 
 export default defineConfig({
     plugins: [
@@ -10,5 +11,6 @@ export default defineConfig({
         }),
         solid({ ssr: true }),
         ssr(),
+        inspect(),
     ],
 })

--- a/packages/main/src/vite/index.ts
+++ b/packages/main/src/vite/index.ts
@@ -113,10 +113,13 @@ export const devtoolsPlugin = (_options: DevtoolsPluginOptions = {}): PluginOpti
                 root: projectRoot,
                 filename: id,
                 sourceFileName: id,
+                sourceMaps: true,
                 plugins,
             })
 
-            return { code: result?.code ?? source }
+            if (result) {
+                return { code: result.code!, map: result.map! }
+            }
         },
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,10 @@ importers:
       vite-plugin-ssr:
         specifier: 0.4.133
         version: 0.4.133(vite@4.4.7)
+    devDependencies:
+      vite-plugin-inspect:
+        specifier: ^0.7.33
+        version: 0.7.33(rollup@3.26.3)(vite@4.4.7)
 
   packages/debugger:
     dependencies:


### PR DESCRIPTION
Fixes #236

This makes browser DevTools show the original source code as the author writes, not the code produced by this plugin.

This can be verified by either checking browser DevTools or using the `vite-plugin-inspect` plugin to log each plugins' output code and source maps.