### PR TITLE
feat(debugger): add createTrackedSignal with reactive storm & cycle detection

### DIFF
--- a/packages/debugger/src/createTrackedSignal.ts
+++ b/packages/debugger/src/createTrackedSignal.ts
@@ -1,0 +1,109 @@
+import {
+  createSignal,
+  type Accessor,
+  type Setter,
+  type Signal,
+  type SignalOptions
+} from 'solid-js'
+
+export interface TrackedSignalOptions<T> extends SignalOptions<T> {
+  /**
+   * Human-readable identifier for telemetry and warnings.
+   */
+  name?: string
+  /**
+   * Maximum allowed state transitions within a single tick window before triggering storm warnings.
+   * @default 50
+   */
+  maxTransitionsPerTick?: number
+  /**
+   * Custom hook called when a reactive storm or recursion threshold is exceeded.
+   */
+  onStorm?: (details: StormDetails<T>) => void
+  /**
+   * If true, throws an Error instead of console.warn when threshold is exceeded.
+   * @default false
+   */
+  throwOnStorm?: boolean
+}
+
+export interface StormDetails<T> {
+  signalName: string
+  transitionsInTick: number
+  lastValue: T
+  nextValue: T
+  stack?: string
+}
+
+const isProduction = typeof process !== 'undefined' && process.env?.NODE_ENV === 'production'
+
+/**
+ * Signal wrapper with development-mode reactive cycle and storm detection.
+ * Monitors update frequency per microtask tick to detect infinite dependency cascades.
+ * Compiles down to standard `createSignal` with zero overhead in production builds.
+ */
+export function createTrackedSignal<T>(
+  initialValue: T,
+  options: TrackedSignalOptions<T> = {}
+): Signal<T> {
+  const [read, rawSet] = createSignal<T>(initialValue, options)
+
+  if (isProduction) {
+    return [read, rawSet]
+  }
+
+  const signalName = options.name ?? `signal_${Math.random().toString(36).slice(2, 8)}`
+  const maxTransitions = options.maxTransitionsPerTick ?? 50
+
+  let transitionCount = 0
+  let resetScheduled = false
+
+  const scheduleReset = (): void => {
+    if (resetScheduled) return
+    resetScheduled = true
+
+    queueMicrotask(() => {
+      transitionCount = 0
+      resetScheduled = false
+    })
+  }
+
+  const trackedSet: Setter<T> = ((valueOrUpdater: unknown) => {
+    transitionCount += 1
+    scheduleReset()
+
+    const previousValue = read()
+    let nextValue: T
+
+    if (typeof valueOrUpdater === 'function') {
+      nextValue = (valueOrUpdater as (prev: T) => T)(previousValue)
+    } else {
+      nextValue = valueOrUpdater as T
+    }
+
+    if (transitionCount > maxTransitions) {
+      const details: StormDetails<T> = {
+        signalName,
+        transitionsInTick: transitionCount,
+        lastValue: previousValue,
+        nextValue,
+        stack: new Error().stack
+      }
+
+      if (options.onStorm) {
+        options.onStorm(details)
+      } else {
+        const message = `[Solid DevTools] Reactive storm detected on '${signalName}'. Exceeded ${maxTransitions} transitions in a single microtask tick.`
+        if (options.throwOnStorm) {
+          throw new Error(message)
+        } else {
+          console.warn(message, details)
+        }
+      }
+    }
+
+    return rawSet(nextValue as Parameters<typeof rawSet>[0])
+  }) as Setter<T>
+
+  return [read, trackedSet]
+}

--- a/packages/debugger/src/index.ts
+++ b/packages/debugger/src/index.ts
@@ -21,3 +21,8 @@ export {
     onOwnerCleanup,
     onParentCleanup,
 } from './main/utils.ts'
+export {
+    createTrackedSignal,
+    type TrackedSignalOptions,
+    type StormDetails,
+} from './createTrackedSignal.ts'

--- a/packages/debugger/test/tracked-signal.test.ts
+++ b/packages/debugger/test/tracked-signal.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { createEffect, createRoot } from 'solid-js'
+import { createTrackedSignal, type StormDetails } from '../src/createTrackedSignal'
+
+describe('createTrackedSignal', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('behaves identically to standard signal for normal updates', () => {
+    createRoot(dispose => {
+      const [count, setCount] = createTrackedSignal(0, { name: 'testCount' })
+
+      expect(count()).toBe(0)
+      setCount(5)
+      expect(count()).toBe(5)
+      setCount(prev => prev + 1)
+      expect(count()).toBe(6)
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      dispose()
+    })
+  })
+
+  it('triggers storm alert when transition threshold is exceeded in a single tick', () => {
+    createRoot(dispose => {
+      const onStorm = vi.fn()
+      const [, setCount] = createTrackedSignal(0, {
+        name: 'stormLoopSignal',
+        maxTransitionsPerTick: 10,
+        onStorm
+      })
+
+      for (let i = 1; i <= 15; i++) {
+        setCount(i)
+      }
+
+      expect(onStorm).toHaveBeenCalled()
+      const details: StormDetails<number> = onStorm.mock.calls[0][0]
+      expect(details.signalName).toBe('stormLoopSignal')
+      expect(details.transitionsInTick).toBe(11)
+      expect(details.nextValue).toBe(11)
+
+      dispose()
+    })
+  })
+
+  it('detects circular updates inside reactive effects', async () => {
+    const onStorm = vi.fn()
+
+    createRoot(dispose => {
+      const [a, setA] = createTrackedSignal(0, {
+        name: 'ping',
+        maxTransitionsPerTick: 20,
+        onStorm
+      })
+      const [b, setB] = createTrackedSignal(0, {
+        name: 'pong',
+        maxTransitionsPerTick: 20
+      })
+
+      createEffect(() => {
+        const valA = a()
+        if (valA < 30) {
+          setB(valA + 1)
+        }
+      })
+
+      createEffect(() => {
+        const valB = b()
+        if (valB < 30) {
+          setA(valB + 1)
+        }
+      })
+
+      dispose()
+    })
+
+    await vi.runAllTicksAsync()
+    expect(onStorm).toHaveBeenCalled()
+  })
+
+  it('resets transition counters after microtask boundary', async () => {
+    const onStorm = vi.fn()
+
+    await createRoot(async dispose => {
+      const [, setCount] = createTrackedSignal(0, {
+        maxTransitionsPerTick: 5,
+        onStorm
+      })
+
+      // 4 updates in tick 1
+      for (let i = 1; i <= 4; i++) setCount(i)
+      expect(onStorm).not.toHaveBeenCalled()
+
+      // Settle microtask
+      await vi.runAllTicksAsync()
+
+      // 4 updates in tick 2
+      for (let i = 5; i <= 8; i++) setCount(i)
+      expect(onStorm).not.toHaveBeenCalled()
+
+      dispose()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This PR introduces `createTrackedSignal` to `@solid-devtools/debugger`:

- **Dev-Mode Storm & Recursion Detection**: Monitors signal transition counts per microtask tick. If an effect or circular reactive loop causes state transitions to exceed `maxTransitionsPerTick` (default: 50), it triggers diagnostic telemetry / warnings with details (`StormDetails`).
- **Zero Overhead in Production**: Bypasses tracking in production builds (`process.env.NODE_ENV === 'production'`) and returns standard `createSignal`.
- **Customizable Handlers**: Supports custom `onStorm` telemetry callbacks or `throwOnStorm: true`.

## Changes
- `packages/debugger/src/createTrackedSignal.ts`: Implementation with tick-based counter resets and stack traces.
- `packages/debugger/src/index.ts`: Re-exported `createTrackedSignal`, `TrackedSignalOptions`, and `StormDetails`.
- `packages/debugger/test/tracked-signal.test.ts`: Vitest test suite covering normal transitions, storm loops, circular effects, and microtask boundary resets.